### PR TITLE
Ignore lockfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ node_modules/
 .env
 .envrc
 
+# lockfiles
+.yarn.lock
+package-lock.json
+
 # misc
 .tern-*
 TAGS

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Since [we decided](https://github.com/micromark/micromark/pull/2#discussion_r236091486) not to commit a lockfile, I suggest adding npm and yarn lockfiles to `.gitignore`. That way we don't have to manually ignore them while commiting or accidentally commiting them, and developers are free of using the package manager of their choice.