### PR TITLE
Add typing for Construct.name

### DIFF
--- a/lib/shared-types.d.ts
+++ b/lib/shared-types.d.ts
@@ -165,6 +165,7 @@ export type Resolve = (events: Event[], context: Tokenizer) => Event[]
 export type Tokenize = (context: Tokenizer, effects: Effects) => State
 
 export interface Construct {
+  name?: string
   tokenize: Tokenize
   partial?: boolean
   resolve?: Resolve


### PR DESCRIPTION
This PR adds typing for commit 71561f3.
<!--
Read the [contributing guidelines](https://github.com/micromark/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/micromark/.github/blob/main/support.md
https://github.com/micromark/.github/blob/main/contributing.md
-->
