### PR TITLE
micromark-util-decode-string: Add missing dependency

### DIFF
--- a/packages/micromark-util-decode-string/package.json
+++ b/packages/micromark-util-decode-string/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "micromark-util-character": "^1.0.0",
     "micromark-util-decode-numeric-character-reference": "^1.0.0",
+    "micromark-util-symbol": "^1.0.0",
     "parse-entities": "^3.0.0"
   },
   "scripts": {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes
A simple change, adds a missing dependency in `micromark-util-decode-string` that yarn berry was complaining about

<!--do not edit: pr-->
