### PR TITLE
feat: add definitions to CompileDataFields

### DIFF
--- a/packages/micromark-util-types/index.js
+++ b/packages/micromark-util-types/index.js
@@ -496,6 +496,10 @@
  * @typedef {Partial<NormalizedHtmlExtension>} HtmlExtension
  *   An HTML extension changes how markdown tokens are serialized.
  *
+ * @typedef Definition
+ * @property {string} [destination]
+ * @property {string} [title]
+ *
  * @typedef _CompileDataFields
  * @property {boolean} lastWasTag
  * @property {boolean} expectFirstItem
@@ -509,6 +513,7 @@
  * @property {boolean} inCodeText
  * @property {string} characterReferenceType
  * @property {Array<boolean>} tightStack
+ * @property {Record<string, Definition>} definitions
  *
  * @typedef {Record<string, unknown> & Partial<_CompileDataFields>} CompileData
  *

--- a/packages/micromark/dev/lib/compile.js
+++ b/packages/micromark/dev/lib/compile.js
@@ -17,6 +17,7 @@
  * @typedef {import('micromark-util-types').CompileOptions} CompileOptions
  * @typedef {import('micromark-util-types').CompileData} CompileData
  * @typedef {import('micromark-util-types').CompileContext} CompileContext
+ * @typedef {import('micromark-util-types').Definition} Definition
  * @typedef {import('micromark-util-types').Compile} Compile
  * @typedef {import('micromark-util-types').Handle} Handle
  * @typedef {import('micromark-util-types').HtmlExtension} HtmlExtension
@@ -29,10 +30,6 @@
  * @property {string} [labelId]
  * @property {string} [label]
  * @property {string} [referenceId]
- * @property {string} [destination]
- * @property {string} [title]
- *
- * @typedef Definition
  * @property {string} [destination]
  * @property {string} [title]
  */
@@ -213,7 +210,10 @@ export function compile(options = {}) {
    *
    * @type {CompileData}
    */
-  const data = {tightStack}
+  const data = {
+    tightStack,
+    definitions
+  }
 
   /**
    * The context for handlers references a couple of useful functions.


### PR DESCRIPTION
fixes #121

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Added the `definitions` records that track the media definitions in the markdown to the compiler data object. This allows extensions to make use of them.

<!--do not edit: pr-->
