### PR TITLE
Fix some tests not actually running

### DIFF
--- a/test/commonmark.js
+++ b/test/commonmark.js
@@ -23,14 +23,12 @@ test('commonmark', function (t) {
   for (key in sections) {
     if (!hasOwnProperty.call(sections, key)) continue
 
+    const section = sections[key]
     t.test(key, function (t) {
       let index = -1
 
-      while (++index < sections[key].length) {
-        t.equal(
-          micromark(sections[key][index].input, options),
-          sections[key][index].output
-        )
+      while (++index < section.length) {
+        t.equal(micromark(section[index].input, options), section[index].output)
       }
 
       t.end()


### PR DESCRIPTION

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

I noticed that the commonmark test only runs the last section from the commonmark test cases ('Textual content') and ignores the rest. This is due to `key` being modified after being captured.

After this change, running commonmark.js individually yields:
```
1..652
# tests 652
# pass  652
```

Without the patch, it printed:
```
1..78
# tests 78
# pass  78
```

<!--do not edit: pr-->
