### PR TITLE
Fix internal types for TS4.9, add `module: node16`

### DIFF
--- a/packages/micromark-core-commonmark/dev/lib/attention.js
+++ b/packages/micromark-core-commonmark/dev/lib/attention.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('micromark-util-types').Construct} Construct
  * @typedef {import('micromark-util-types').Tokenizer} Tokenizer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').Resolver} Resolver
  * @typedef {import('micromark-util-types').State} State
  * @typedef {import('micromark-util-types').Token} Token
@@ -194,7 +195,10 @@ function resolveAllAttention(events, context) {
   return events
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeAttention(effects, ok) {
   const attentionMarkers = this.parser.constructs.attentionMarkers.null
   const previous = this.previous

--- a/packages/micromark-core-commonmark/dev/lib/autolink.js
+++ b/packages/micromark-core-commonmark/dev/lib/autolink.js
@@ -18,7 +18,10 @@ import {types} from 'micromark-util-symbol/types.js'
 /** @type {Construct} */
 export const autolink = {name: 'autolink', tokenize: tokenizeAutolink}
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeAutolink(effects, ok, nok) {
   let size = 1
 

--- a/packages/micromark-core-commonmark/dev/lib/blank-line.js
+++ b/packages/micromark-core-commonmark/dev/lib/blank-line.js
@@ -12,7 +12,10 @@ import {types} from 'micromark-util-symbol/types.js'
 /** @type {Construct} */
 export const blankLine = {tokenize: tokenizeBlankLine, partial: true}
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeBlankLine(effects, ok, nok) {
   return factorySpace(effects, afterWhitespace, types.linePrefix)
 

--- a/packages/micromark-core-commonmark/dev/lib/block-quote.js
+++ b/packages/micromark-core-commonmark/dev/lib/block-quote.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('micromark-util-types').Construct} Construct
  * @typedef {import('micromark-util-types').Tokenizer} Tokenizer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').Exiter} Exiter
  * @typedef {import('micromark-util-types').State} State
  */
@@ -20,7 +21,10 @@ export const blockQuote = {
   exit
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeBlockQuoteStart(effects, ok, nok) {
   const self = this
 
@@ -63,7 +67,10 @@ function tokenizeBlockQuoteStart(effects, ok, nok) {
   }
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeBlockQuoteContinuation(effects, ok, nok) {
   return factorySpace(
     effects,

--- a/packages/micromark-core-commonmark/dev/lib/character-escape.js
+++ b/packages/micromark-core-commonmark/dev/lib/character-escape.js
@@ -15,7 +15,10 @@ export const characterEscape = {
   tokenize: tokenizeCharacterEscape
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeCharacterEscape(effects, ok, nok) {
   return start
 

--- a/packages/micromark-core-commonmark/dev/lib/character-reference.js
+++ b/packages/micromark-core-commonmark/dev/lib/character-reference.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('micromark-util-types').Construct} Construct
  * @typedef {import('micromark-util-types').Tokenizer} Tokenizer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').State} State
  * @typedef {import('micromark-util-types').Code} Code
  */
@@ -22,7 +23,10 @@ export const characterReference = {
   tokenize: tokenizeCharacterReference
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeCharacterReference(effects, ok, nok) {
   const self = this
   let size = 0

--- a/packages/micromark-core-commonmark/dev/lib/code-fenced.js
+++ b/packages/micromark-core-commonmark/dev/lib/code-fenced.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('micromark-util-types').Construct} Construct
  * @typedef {import('micromark-util-types').Tokenizer} Tokenizer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').State} State
  * @typedef {import('micromark-util-types').Code} Code
  */
@@ -22,7 +23,10 @@ export const codeFenced = {
   concrete: true
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeCodeFenced(effects, ok, nok) {
   const self = this
   /** @type {Construct} */
@@ -167,7 +171,10 @@ function tokenizeCodeFenced(effects, ok, nok) {
     return ok(code)
   }
 
-  /** @type {Tokenizer} */
+  /**
+   * @this {TokenizeContext}
+   * @type {Tokenizer}
+   */
   function tokenizeNonLazyLine(effects, ok, nok) {
     const self = this
 
@@ -188,7 +195,10 @@ function tokenizeCodeFenced(effects, ok, nok) {
     }
   }
 
-  /** @type {Tokenizer} */
+  /**
+   * @this {TokenizeContext}
+   * @type {Tokenizer}
+   */
   function tokenizeClosingFence(effects, ok, nok) {
     let size = 0
 

--- a/packages/micromark-core-commonmark/dev/lib/code-indented.js
+++ b/packages/micromark-core-commonmark/dev/lib/code-indented.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('micromark-util-types').Construct} Construct
  * @typedef {import('micromark-util-types').Tokenizer} Tokenizer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').Resolver} Resolver
  * @typedef {import('micromark-util-types').Token} Token
  * @typedef {import('micromark-util-types').State} State
@@ -21,7 +22,10 @@ export const codeIndented = {
 /** @type {Construct} */
 const indentedContent = {tokenize: tokenizeIndentedContent, partial: true}
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeCodeIndented(effects, ok, nok) {
   const self = this
   return start
@@ -79,7 +83,10 @@ function tokenizeCodeIndented(effects, ok, nok) {
   }
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeIndentedContent(effects, ok, nok) {
   const self = this
 

--- a/packages/micromark-core-commonmark/dev/lib/code-text.js
+++ b/packages/micromark-core-commonmark/dev/lib/code-text.js
@@ -2,6 +2,7 @@
  * @typedef {import('micromark-util-types').Construct} Construct
  * @typedef {import('micromark-util-types').Resolver} Resolver
  * @typedef {import('micromark-util-types').Tokenizer} Tokenizer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').Previous} Previous
  * @typedef {import('micromark-util-types').Token} Token
  * @typedef {import('micromark-util-types').State} State
@@ -83,7 +84,10 @@ function resolveCodeText(events) {
   return events
 }
 
-/** @type {Previous} */
+/**
+ * @this {TokenizeContext}
+ * @type {Previous}
+ */
 function previous(code) {
   // If there is a previous code, there will always be a tail.
   return (
@@ -92,7 +96,10 @@ function previous(code) {
   )
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeCodeText(effects, ok, nok) {
   const self = this
   let sizeOpen = 0

--- a/packages/micromark-core-commonmark/dev/lib/content.js
+++ b/packages/micromark-core-commonmark/dev/lib/content.js
@@ -2,6 +2,7 @@
  * @typedef {import('micromark-util-types').Construct} Construct
  * @typedef {import('micromark-util-types').Resolver} Resolver
  * @typedef {import('micromark-util-types').Tokenizer} Tokenizer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').Token} Token
  * @typedef {import('micromark-util-types').State} State
  */
@@ -34,7 +35,10 @@ function resolveContent(events) {
   return events
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeContent(effects, ok) {
   /** @type {Token} */
   let previous
@@ -95,7 +99,10 @@ function tokenizeContent(effects, ok) {
   }
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeContinuation(effects, ok, nok) {
   const self = this
 

--- a/packages/micromark-core-commonmark/dev/lib/definition.js
+++ b/packages/micromark-core-commonmark/dev/lib/definition.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('micromark-util-types').Construct} Construct
  * @typedef {import('micromark-util-types').Tokenizer} Tokenizer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').State} State
  */
 
@@ -24,7 +25,10 @@ export const definition = {name: 'definition', tokenize: tokenizeDefinition}
 /** @type {Construct} */
 const titleConstruct = {tokenize: tokenizeTitle, partial: true}
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeDefinition(effects, ok, nok) {
   const self = this
   /** @type {string} */
@@ -97,7 +101,10 @@ function tokenizeDefinition(effects, ok, nok) {
   }
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeTitle(effects, ok, nok) {
   return start
 

--- a/packages/micromark-core-commonmark/dev/lib/hard-break-escape.js
+++ b/packages/micromark-core-commonmark/dev/lib/hard-break-escape.js
@@ -15,7 +15,10 @@ export const hardBreakEscape = {
   tokenize: tokenizeHardBreakEscape
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeHardBreakEscape(effects, ok, nok) {
   return start
 

--- a/packages/micromark-core-commonmark/dev/lib/heading-atx.js
+++ b/packages/micromark-core-commonmark/dev/lib/heading-atx.js
@@ -2,6 +2,7 @@
  * @typedef {import('micromark-util-types').Construct} Construct
  * @typedef {import('micromark-util-types').Resolver} Resolver
  * @typedef {import('micromark-util-types').Tokenizer} Tokenizer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').Token} Token
  * @typedef {import('micromark-util-types').State} State
  */
@@ -81,7 +82,10 @@ function resolveHeadingAtx(events, context) {
   return events
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeHeadingAtx(effects, ok, nok) {
   const self = this
   let size = 0

--- a/packages/micromark-core-commonmark/dev/lib/html-flow.js
+++ b/packages/micromark-core-commonmark/dev/lib/html-flow.js
@@ -2,6 +2,7 @@
  * @typedef {import('micromark-util-types').Construct} Construct
  * @typedef {import('micromark-util-types').Resolver} Resolver
  * @typedef {import('micromark-util-types').Tokenizer} Tokenizer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').State} State
  * @typedef {import('micromark-util-types').Code} Code
  */
@@ -56,7 +57,10 @@ function resolveToHtmlFlow(events) {
   return events
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeHtmlFlow(effects, ok, nok) {
   const self = this
   /** @type {number} */
@@ -454,7 +458,10 @@ function tokenizeHtmlFlow(effects, ok, nok) {
     return continuation(code)
   }
 
-  /** @type {Tokenizer} */
+  /**
+   * @this {TokenizeContext}
+   * @type {Tokenizer}
+   */
   function htmlLineEnd(effects, ok, nok) {
     return start
 
@@ -557,7 +564,10 @@ function tokenizeHtmlFlow(effects, ok, nok) {
   }
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeNextBlank(effects, ok, nok) {
   return start
 

--- a/packages/micromark-core-commonmark/dev/lib/html-text.js
+++ b/packages/micromark-core-commonmark/dev/lib/html-text.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('micromark-util-types').Construct} Construct
  * @typedef {import('micromark-util-types').Tokenizer} Tokenizer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').State} State
  * @typedef {import('micromark-util-types').Code} Code
  */
@@ -21,7 +22,10 @@ import {types} from 'micromark-util-symbol/types.js'
 /** @type {Construct} */
 export const htmlText = {name: 'htmlText', tokenize: tokenizeHtmlText}
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeHtmlText(effects, ok, nok) {
   const self = this
   /** @type {NonNullable<Code>|undefined} */

--- a/packages/micromark-core-commonmark/dev/lib/label-end.js
+++ b/packages/micromark-core-commonmark/dev/lib/label-end.js
@@ -2,6 +2,7 @@
  * @typedef {import('micromark-util-types').Construct} Construct
  * @typedef {import('micromark-util-types').Resolver} Resolver
  * @typedef {import('micromark-util-types').Tokenizer} Tokenizer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').Event} Event
  * @typedef {import('micromark-util-types').Token} Token
  * @typedef {import('micromark-util-types').State} State
@@ -167,7 +168,10 @@ function resolveToLabelEnd(events, context) {
   return events
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeLabelEnd(effects, ok, nok) {
   const self = this
   let index = self.events.length
@@ -291,7 +295,10 @@ function tokenizeLabelEnd(effects, ok, nok) {
   }
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeResource(effects, ok, nok) {
   return start
 
@@ -410,7 +417,10 @@ function tokenizeResource(effects, ok, nok) {
   }
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeFullReference(effects, ok, nok) {
   const self = this
 
@@ -460,7 +470,10 @@ function tokenizeFullReference(effects, ok, nok) {
   }
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeCollapsedReference(effects, ok, nok) {
   return start
 

--- a/packages/micromark-core-commonmark/dev/lib/label-start-image.js
+++ b/packages/micromark-core-commonmark/dev/lib/label-start-image.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('micromark-util-types').Construct} Construct
  * @typedef {import('micromark-util-types').Tokenizer} Tokenizer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').State} State
  */
 
@@ -16,7 +17,10 @@ export const labelStartImage = {
   resolveAll: labelEnd.resolveAll
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeLabelStartImage(effects, ok, nok) {
   const self = this
 

--- a/packages/micromark-core-commonmark/dev/lib/label-start-link.js
+++ b/packages/micromark-core-commonmark/dev/lib/label-start-link.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('micromark-util-types').Construct} Construct
  * @typedef {import('micromark-util-types').Tokenizer} Tokenizer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').State} State
  */
 
@@ -16,7 +17,10 @@ export const labelStartLink = {
   resolveAll: labelEnd.resolveAll
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeLabelStartLink(effects, ok, nok) {
   const self = this
 

--- a/packages/micromark-core-commonmark/dev/lib/line-ending.js
+++ b/packages/micromark-core-commonmark/dev/lib/line-ending.js
@@ -12,7 +12,10 @@ import {types} from 'micromark-util-symbol/types.js'
 /** @type {Construct} */
 export const lineEnding = {name: 'lineEnding', tokenize: tokenizeLineEnding}
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeLineEnding(effects, ok) {
   return start
 

--- a/packages/micromark-core-commonmark/dev/lib/setext-underline.js
+++ b/packages/micromark-core-commonmark/dev/lib/setext-underline.js
@@ -2,6 +2,7 @@
  * @typedef {import('micromark-util-types').Construct} Construct
  * @typedef {import('micromark-util-types').Resolver} Resolver
  * @typedef {import('micromark-util-types').Tokenizer} Tokenizer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').State} State
  * @typedef {import('micromark-util-types').Code} Code
  */
@@ -83,7 +84,10 @@ function resolveToSetextUnderline(events, context) {
   return events
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeSetextUnderline(effects, ok, nok) {
   const self = this
   let index = self.events.length

--- a/packages/micromark-core-commonmark/dev/lib/thematic-break.js
+++ b/packages/micromark-core-commonmark/dev/lib/thematic-break.js
@@ -18,7 +18,10 @@ export const thematicBreak = {
   tokenize: tokenizeThematicBreak
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeThematicBreak(effects, ok, nok) {
   let size = 0
   /** @type {NonNullable<Code>} */

--- a/packages/micromark-core-commonmark/package.json
+++ b/packages/micromark-core-commonmark/package.json
@@ -35,6 +35,7 @@
     "index.js"
   ],
   "exports": {
+    "types": "./dev/index.d.ts",
     "development": "./dev/index.js",
     "default": "./index.js"
   },

--- a/packages/micromark-factory-destination/package.json
+++ b/packages/micromark-factory-destination/package.json
@@ -34,6 +34,7 @@
     "index.js"
   ],
   "exports": {
+    "types": "./dev/index.d.ts",
     "development": "./dev/index.js",
     "default": "./index.js"
   },

--- a/packages/micromark-factory-destination/readme.md
+++ b/packages/micromark-factory-destination/readme.md
@@ -51,7 +51,10 @@ import {codes} from 'micromark-util-symbol/codes'
 import {types} from 'micromark-util-symbol/types'
 
 // A micromark tokenizer that uses the factory:
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeResource(effects, ok, nok) {
   return start
 

--- a/packages/micromark-factory-label/package.json
+++ b/packages/micromark-factory-label/package.json
@@ -34,6 +34,7 @@
     "index.js"
   ],
   "exports": {
+    "types": "./dev/index.d.ts",
     "development": "./dev/index.js",
     "default": "./index.js"
   },

--- a/packages/micromark-factory-label/readme.md
+++ b/packages/micromark-factory-label/readme.md
@@ -52,7 +52,10 @@ import {codes} from 'micromark-util-symbol/codes'
 import {types} from 'micromark-util-symbol/types'
 
 // A micromark tokenizer that uses the factory:
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeDefinition(effects, ok, nok) {
   return start
 

--- a/packages/micromark-factory-space/package.json
+++ b/packages/micromark-factory-space/package.json
@@ -34,6 +34,7 @@
     "index.js"
   ],
   "exports": {
+    "types": "./dev/index.d.ts",
     "development": "./dev/index.js",
     "default": "./index.js"
   },

--- a/packages/micromark-factory-space/readme.md
+++ b/packages/micromark-factory-space/readme.md
@@ -52,7 +52,10 @@ import {codes} from 'micromark-util-symbol/codes'
 import {types} from 'micromark-util-symbol/types'
 
 // A micromark tokenizer that uses the factory:
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeCodeFenced(effects, ok, nok) {
   return start
 

--- a/packages/micromark-factory-title/package.json
+++ b/packages/micromark-factory-title/package.json
@@ -34,6 +34,7 @@
     "index.js"
   ],
   "exports": {
+    "types": "./dev/index.d.ts",
     "development": "./dev/index.js",
     "default": "./index.js"
   },

--- a/packages/micromark-factory-title/readme.md
+++ b/packages/micromark-factory-title/readme.md
@@ -51,7 +51,10 @@ import {codes} from 'micromark-util-symbol/codes'
 import {types} from 'micromark-util-symbol/types'
 
 // A micromark tokenizer that uses the factory:
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeDefinition(effects, ok, nok) {
   return start
 

--- a/packages/micromark-factory-whitespace/package.json
+++ b/packages/micromark-factory-whitespace/package.json
@@ -34,6 +34,7 @@
     "index.js"
   ],
   "exports": {
+    "types": "./dev/index.d.ts",
     "development": "./dev/index.js",
     "default": "./index.js"
   },

--- a/packages/micromark-factory-whitespace/readme.md
+++ b/packages/micromark-factory-whitespace/readme.md
@@ -52,7 +52,10 @@ import {codes} from 'micromark-util-symbol/codes'
 import {types} from 'micromark-util-symbol/types'
 
 // A micromark tokenizer that uses the factory:
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeTitle(effects, ok, nok) {
   return start
 

--- a/packages/micromark-util-character/package.json
+++ b/packages/micromark-util-character/package.json
@@ -36,6 +36,7 @@
     "index.js"
   ],
   "exports": {
+    "types": "./dev/index.d.ts",
     "development": "./dev/index.js",
     "default": "./index.js"
   },

--- a/packages/micromark-util-chunked/package.json
+++ b/packages/micromark-util-chunked/package.json
@@ -37,6 +37,7 @@
     "index.js"
   ],
   "exports": {
+    "types": "./dev/index.d.ts",
     "development": "./dev/index.js",
     "default": "./index.js"
   },

--- a/packages/micromark-util-classify-character/package.json
+++ b/packages/micromark-util-classify-character/package.json
@@ -37,6 +37,7 @@
     "index.js"
   ],
   "exports": {
+    "types": "./dev/index.d.ts",
     "development": "./dev/index.js",
     "default": "./index.js"
   },

--- a/packages/micromark-util-classify-character/readme.md
+++ b/packages/micromark-util-classify-character/readme.md
@@ -46,7 +46,10 @@ In browsers with [`esm.sh`][esmsh]:
 ## Use
 
 ```js
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeAttention(effects, ok) {
   return start
 

--- a/packages/micromark-util-decode-numeric-character-reference/package.json
+++ b/packages/micromark-util-decode-numeric-character-reference/package.json
@@ -39,6 +39,7 @@
     "index.js"
   ],
   "exports": {
+    "types": "./dev/index.d.ts",
     "development": "./dev/index.js",
     "default": "./index.js"
   },

--- a/packages/micromark-util-decode-string/package.json
+++ b/packages/micromark-util-decode-string/package.json
@@ -39,6 +39,7 @@
     "index.js"
   ],
   "exports": {
+    "types": "./dev/index.d.ts",
     "development": "./dev/index.js",
     "default": "./index.js"
   },

--- a/packages/micromark-util-normalize-identifier/package.json
+++ b/packages/micromark-util-normalize-identifier/package.json
@@ -37,6 +37,7 @@
     "index.js"
   ],
   "exports": {
+    "types": "./dev/index.d.ts",
     "development": "./dev/index.js",
     "default": "./index.js"
   },

--- a/packages/micromark-util-sanitize-uri/package.json
+++ b/packages/micromark-util-sanitize-uri/package.json
@@ -37,6 +37,7 @@
     "index.js"
   ],
   "exports": {
+    "types": "./dev/index.d.ts",
     "development": "./dev/index.js",
     "default": "./index.js"
   },

--- a/packages/micromark-util-subtokenize/package.json
+++ b/packages/micromark-util-subtokenize/package.json
@@ -35,6 +35,7 @@
     "index.js"
   ],
   "exports": {
+    "types": "./dev/index.d.ts",
     "development": "./dev/index.js",
     "default": "./index.js"
   },

--- a/packages/micromark/dev/lib/compile.js
+++ b/packages/micromark/dev/lib/compile.js
@@ -478,7 +478,10 @@ export function compile(options = {}) {
   // Handlers.
   //
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onenterlistordered(token) {
     tightStack.push(!token._loose)
     lineEndingIfNeeded()
@@ -486,7 +489,10 @@ export function compile(options = {}) {
     setData('expectFirstItem', true)
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onenterlistunordered(token) {
     tightStack.push(!token._loose)
     lineEndingIfNeeded()
@@ -494,7 +500,10 @@ export function compile(options = {}) {
     setData('expectFirstItem', true)
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onenterlistitemvalue(token) {
     if (getData('expectFirstItem')) {
       const value = Number.parseInt(
@@ -508,7 +517,10 @@ export function compile(options = {}) {
     }
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onenterlistitemmarker() {
     if (getData('expectFirstItem')) {
       tag('>')
@@ -523,7 +535,10 @@ export function compile(options = {}) {
     setData('lastWasTag')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitlistordered() {
     onexitlistitem()
     tightStack.pop()
@@ -531,7 +546,10 @@ export function compile(options = {}) {
     tag('</ol>')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitlistunordered() {
     onexitlistitem()
     tightStack.pop()
@@ -539,7 +557,10 @@ export function compile(options = {}) {
     tag('</ul>')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitlistitem() {
     if (getData('lastWasTag') && !getData('slurpAllLineEndings')) {
       lineEndingIfNeeded()
@@ -549,14 +570,20 @@ export function compile(options = {}) {
     setData('slurpAllLineEndings')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onenterblockquote() {
     tightStack.push(false)
     lineEndingIfNeeded()
     tag('<blockquote>')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitblockquote() {
     tightStack.pop()
     lineEndingIfNeeded()
@@ -564,7 +591,10 @@ export function compile(options = {}) {
     setData('slurpAllLineEndings')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onenterparagraph() {
     if (!tightStack[tightStack.length - 1]) {
       lineEndingIfNeeded()
@@ -574,7 +604,10 @@ export function compile(options = {}) {
     setData('slurpAllLineEndings')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitparagraph() {
     if (tightStack[tightStack.length - 1]) {
       setData('slurpAllLineEndings', true)
@@ -583,20 +616,29 @@ export function compile(options = {}) {
     }
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onentercodefenced() {
     lineEndingIfNeeded()
     tag('<pre><code')
     setData('fencesCount', 0)
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitcodefencedfenceinfo() {
     const value = resume()
     tag(' class="language-' + value + '"')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitcodefencedfence() {
     const count = getData('fencesCount') || 0
 
@@ -608,13 +650,19 @@ export function compile(options = {}) {
     setData('fencesCount', count + 1)
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onentercodeindented() {
     lineEndingIfNeeded()
     tag('<pre><code>')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitflowcode() {
     const count = getData('fencesCount')
 
@@ -646,39 +694,60 @@ export function compile(options = {}) {
     setData('slurpOneLineEnding')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onenterimage() {
     mediaStack.push({image: true})
     tags = undefined // Disallow tags.
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onenterlink() {
     mediaStack.push({})
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitlabeltext(token) {
     mediaStack[mediaStack.length - 1].labelId = this.sliceSerialize(token)
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitlabel() {
     mediaStack[mediaStack.length - 1].label = resume()
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitreferencestring(token) {
     mediaStack[mediaStack.length - 1].referenceId = this.sliceSerialize(token)
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onenterresource() {
     buffer() // We can have line endings in the resource, ignore them.
     mediaStack[mediaStack.length - 1].destination = ''
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onenterresourcedestinationstring() {
     buffer()
     // Ignore encoding the result, as we’ll first percent encode the url and
@@ -686,18 +755,27 @@ export function compile(options = {}) {
     setData('ignoreEncode', true)
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitresourcedestinationstring() {
     mediaStack[mediaStack.length - 1].destination = resume()
     setData('ignoreEncode')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitresourcetitlestring() {
     mediaStack[mediaStack.length - 1].title = resume()
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitmedia() {
     let index = mediaStack.length - 1 // Skip current.
     const media = mediaStack[index]
@@ -753,37 +831,55 @@ export function compile(options = {}) {
     mediaStack.pop()
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onenterdefinition() {
     buffer()
     mediaStack.push({})
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitdefinitionlabelstring(token) {
     // Discard label, use the source content instead.
     resume()
     mediaStack[mediaStack.length - 1].labelId = this.sliceSerialize(token)
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onenterdefinitiondestinationstring() {
     buffer()
     setData('ignoreEncode', true)
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitdefinitiondestinationstring() {
     mediaStack[mediaStack.length - 1].destination = resume()
     setData('ignoreEncode')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitdefinitiontitlestring() {
     mediaStack[mediaStack.length - 1].title = resume()
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitdefinition() {
     const media = mediaStack[mediaStack.length - 1]
     assert(media.labelId !== undefined, 'media should have `labelId`')
@@ -798,12 +894,18 @@ export function compile(options = {}) {
     mediaStack.pop()
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onentercontent() {
     setData('slurpAllLineEndings', true)
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitatxheadingsequence(token) {
     // Exit for further sequences.
     if (getData('headingRank')) return
@@ -812,24 +914,36 @@ export function compile(options = {}) {
     tag('<h' + getData('headingRank') + '>')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onentersetextheading() {
     buffer()
     setData('slurpAllLineEndings')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitsetextheadingtext() {
     setData('slurpAllLineEndings', true)
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitatxheading() {
     tag('</h' + getData('headingRank') + '>')
     setData('headingRank')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitsetextheadinglinesequence(token) {
     setData(
       'headingRank',
@@ -837,7 +951,10 @@ export function compile(options = {}) {
     )
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitsetextheading() {
     const value = resume()
     lineEndingIfNeeded()
@@ -848,12 +965,18 @@ export function compile(options = {}) {
     setData('headingRank')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitdata(token) {
     raw(encode(this.sliceSerialize(token)))
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitlineending(token) {
     if (getData('slurpAllLineEndings')) {
       return
@@ -872,79 +995,121 @@ export function compile(options = {}) {
     raw(encode(this.sliceSerialize(token)))
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitcodeflowvalue(token) {
     raw(encode(this.sliceSerialize(token)))
     setData('flowCodeSeenData', true)
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexithardbreak() {
     tag('<br />')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onenterhtmlflow() {
     lineEndingIfNeeded()
     onenterhtml()
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexithtml() {
     setData('ignoreEncode')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onenterhtml() {
     if (options.allowDangerousHtml) {
       setData('ignoreEncode', true)
     }
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onenteremphasis() {
     tag('<em>')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onenterstrong() {
     tag('<strong>')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onentercodetext() {
     setData('inCodeText', true)
     tag('<code>')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitcodetext() {
     setData('inCodeText')
     tag('</code>')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitemphasis() {
     tag('</em>')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitstrong() {
     tag('</strong>')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitthematicbreak() {
     lineEndingIfNeeded()
     tag('<hr />')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitcharacterreferencemarker(token) {
     setData('characterReferenceType', token.type)
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitcharacterreferencevalue(token) {
     let value = this.sliceSerialize(token)
 
@@ -965,7 +1130,10 @@ export function compile(options = {}) {
     setData('characterReferenceType')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitautolinkprotocol(token) {
     const uri = this.sliceSerialize(token)
     tag(
@@ -980,7 +1148,10 @@ export function compile(options = {}) {
     tag('</a>')
   }
 
-  /** @type {Handle} */
+  /**
+   * @this {CompileContext}
+   * @type {Handle}
+   */
   function onexitautolinkemail(token) {
     const uri = this.sliceSerialize(token)
     tag('<a href="' + sanitizeUri('mailto:' + uri) + '">')

--- a/packages/micromark/dev/lib/compile.js
+++ b/packages/micromark/dev/lib/compile.js
@@ -22,6 +22,7 @@
  * @typedef {import('micromark-util-types').Handle} Handle
  * @typedef {import('micromark-util-types').HtmlExtension} HtmlExtension
  * @typedef {import('micromark-util-types').NormalizedHtmlExtension} NormalizedHtmlExtension
+ * @typedef {import('micromark-util-types').Token} Token
  */
 
 /**
@@ -517,10 +518,6 @@ export function compile(options = {}) {
     }
   }
 
-  /**
-   * @this {CompileContext}
-   * @type {Handle}
-   */
   function onenterlistitemmarker() {
     if (getData('expectFirstItem')) {
       tag('>')
@@ -535,10 +532,6 @@ export function compile(options = {}) {
     setData('lastWasTag')
   }
 
-  /**
-   * @this {CompileContext}
-   * @type {Handle}
-   */
   function onexitlistordered() {
     onexitlistitem()
     tightStack.pop()
@@ -546,10 +539,6 @@ export function compile(options = {}) {
     tag('</ol>')
   }
 
-  /**
-   * @this {CompileContext}
-   * @type {Handle}
-   */
   function onexitlistunordered() {
     onexitlistitem()
     tightStack.pop()
@@ -557,10 +546,6 @@ export function compile(options = {}) {
     tag('</ul>')
   }
 
-  /**
-   * @this {CompileContext}
-   * @type {Handle}
-   */
   function onexitlistitem() {
     if (getData('lastWasTag') && !getData('slurpAllLineEndings')) {
       lineEndingIfNeeded()
@@ -1012,87 +997,47 @@ export function compile(options = {}) {
     tag('<br />')
   }
 
-  /**
-   * @this {CompileContext}
-   * @type {Handle}
-   */
   function onenterhtmlflow() {
     lineEndingIfNeeded()
     onenterhtml()
   }
 
-  /**
-   * @this {CompileContext}
-   * @type {Handle}
-   */
   function onexithtml() {
     setData('ignoreEncode')
   }
 
-  /**
-   * @this {CompileContext}
-   * @type {Handle}
-   */
   function onenterhtml() {
     if (options.allowDangerousHtml) {
       setData('ignoreEncode', true)
     }
   }
 
-  /**
-   * @this {CompileContext}
-   * @type {Handle}
-   */
   function onenteremphasis() {
     tag('<em>')
   }
 
-  /**
-   * @this {CompileContext}
-   * @type {Handle}
-   */
   function onenterstrong() {
     tag('<strong>')
   }
 
-  /**
-   * @this {CompileContext}
-   * @type {Handle}
-   */
   function onentercodetext() {
     setData('inCodeText', true)
     tag('<code>')
   }
 
-  /**
-   * @this {CompileContext}
-   * @type {Handle}
-   */
   function onexitcodetext() {
     setData('inCodeText')
     tag('</code>')
   }
 
-  /**
-   * @this {CompileContext}
-   * @type {Handle}
-   */
   function onexitemphasis() {
     tag('</em>')
   }
 
-  /**
-   * @this {CompileContext}
-   * @type {Handle}
-   */
   function onexitstrong() {
     tag('</strong>')
   }
 
-  /**
-   * @this {CompileContext}
-   * @type {Handle}
-   */
   function onexitthematicbreak() {
     lineEndingIfNeeded()
     tag('<hr />')
@@ -1100,7 +1045,7 @@ export function compile(options = {}) {
 
   /**
    * @this {CompileContext}
-   * @type {Handle}
+   * @param {Token} token
    */
   function onexitcharacterreferencemarker(token) {
     setData('characterReferenceType', token.type)

--- a/packages/micromark/dev/lib/initialize/content.js
+++ b/packages/micromark/dev/lib/initialize/content.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('micromark-util-types').InitialConstruct} InitialConstruct
  * @typedef {import('micromark-util-types').Initializer} Initializer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').Token} Token
  * @typedef {import('micromark-util-types').State} State
  */
@@ -15,7 +16,10 @@ import {types} from 'micromark-util-symbol/types.js'
 /** @type {InitialConstruct} */
 export const content = {tokenize: initializeContent}
 
-/** @type {Initializer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Initializer}
+ */
 function initializeContent(effects) {
   const contentStart = effects.attempt(
     this.parser.constructs.contentInitial,

--- a/packages/micromark/dev/lib/initialize/document.js
+++ b/packages/micromark/dev/lib/initialize/document.js
@@ -28,7 +28,10 @@ export const document = {tokenize: initializeDocument}
 /** @type {Construct} */
 const containerConstruct = {tokenize: tokenizeContainer}
 
-/** @type {Initializer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Initializer}
+ */
 function initializeDocument(effects) {
   const self = this
   /** @type {Array<StackItem>} */
@@ -409,7 +412,10 @@ function initializeDocument(effects) {
   }
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeContainer(effects, ok, nok) {
   return factorySpace(
     effects,

--- a/packages/micromark/dev/lib/initialize/flow.js
+++ b/packages/micromark/dev/lib/initialize/flow.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('micromark-util-types').InitialConstruct} InitialConstruct
  * @typedef {import('micromark-util-types').Initializer} Initializer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').State} State
  */
 
@@ -14,7 +15,10 @@ import {types} from 'micromark-util-symbol/types.js'
 /** @type {InitialConstruct} */
 export const flow = {tokenize: initializeFlow}
 
-/** @type {Initializer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Initializer}
+ */
 function initializeFlow(effects) {
   const self = this
   const initial = effects.attempt(

--- a/packages/micromark/dev/lib/initialize/text.js
+++ b/packages/micromark/dev/lib/initialize/text.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('micromark-util-types').Resolver} Resolver
  * @typedef {import('micromark-util-types').Initializer} Initializer
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  * @typedef {import('micromark-util-types').Construct} Construct
  * @typedef {import('micromark-util-types').InitialConstruct} InitialConstruct
  * @typedef {import('micromark-util-types').State} State
@@ -27,7 +28,10 @@ function initializeFactory(field) {
     )
   }
 
-  /** @type {Initializer} */
+  /**
+   * @this {TokenizeContext}
+   * @type {Initializer}
+   */
   function initializeText(effects) {
     const self = this
     const constructs = this.parser.constructs[field]

--- a/packages/micromark/package.json
+++ b/packages/micromark/package.json
@@ -53,46 +53,57 @@
   ],
   "exports": {
     ".": {
+      "types": "./dev/index.d.ts",
       "development": "./dev/index.js",
       "default": "./index.js"
     },
     "./stream": {
+      "types": "./dev/stream.d.ts",
       "development": "./dev/stream.js",
       "default": "./stream.js"
     },
     "./stream.js": {
+      "types": "./dev/stream.d.ts",
       "development": "./dev/stream.js",
       "default": "./stream.js"
     },
     "./lib/compile": {
+      "types": "./dev/lib/compile.d.ts",
       "development": "./dev/lib/compile.js",
       "default": "./lib/compile.js"
     },
     "./lib/compile.js": {
+      "types": "./dev/lib/compile.d.ts",
       "development": "./dev/lib/compile.js",
       "default": "./lib/compile.js"
     },
     "./lib/parse": {
+      "types": "./dev/lib/parse.d.ts",
       "development": "./dev/lib/parse.js",
       "default": "./lib/parse.js"
     },
     "./lib/parse.js": {
+      "types": "./dev/lib/parse.d.ts",
       "development": "./dev/lib/parse.js",
       "default": "./lib/parse.js"
     },
     "./lib/postprocess": {
+      "types": "./dev/lib/postprocess.d.ts",
       "development": "./dev/lib/postprocess.js",
       "default": "./lib/postprocess.js"
     },
     "./lib/postprocess.js": {
+      "types": "./dev/lib/postprocess.d.ts",
       "development": "./dev/lib/postprocess.js",
       "default": "./lib/postprocess.js"
     },
     "./lib/preprocess": {
+      "types": "./dev/lib/preprocess.d.ts",
       "development": "./dev/lib/preprocess.js",
       "default": "./lib/preprocess.js"
     },
     "./lib/preprocess.js": {
+      "types": "./dev/lib/preprocess.d.ts",
       "development": "./dev/lib/preprocess.js",
       "default": "./lib/preprocess.js"
     }

--- a/packages/micromark/readme.md
+++ b/packages/micromark/readme.md
@@ -340,7 +340,7 @@ Some exemplary goals are:
 8.  I want to support our legacy flavor of markdown-like syntax
 
 These can be solved in different ways and which solution is best is both
-subjective and dependant on unique needs.
+subjective and dependent on unique needs.
 Often, there is already a solution in the form of an existing remark or rehype
 plugin.
 Respectively, their solutions are:
@@ -382,7 +382,7 @@ Looking at these from a higher level, they can be categorized:
     trees*, but adds a new meaning to certain things which already have
     semantics in markdown.
 
-    Some examples in pseudo code:
+    Some examples in pseudocode:
 
     ````markdown
     *   **A list item with the first paragraph bold**

--- a/packages/micromark/readme.md
+++ b/packages/micromark/readme.md
@@ -526,7 +526,7 @@ For this case, I can see the following:
 To keep things as simple as possible, let’s not support a block syntax, see
 spaces as special, support line endings, or support nested braces.
 But to learn interesting things, we *will* support character escapes and
-\-references.
+-references.
 
 Note that this particular case is already solved quite nicely by
 [`micromark-extension-mdx-expression`][mdx-expression].

--- a/readme.md
+++ b/readme.md
@@ -526,7 +526,7 @@ For this case, I can see the following:
 To keep things as simple as possible, let’s not support a block syntax, see
 spaces as special, support line endings, or support nested braces.
 But to learn interesting things, we *will* support character escapes and
-\-references.
+-references.
 
 Note that this particular case is already solved quite nicely by
 [`micromark-extension-mdx-expression`][mdx-expression].

--- a/test/extension.js
+++ b/test/extension.js
@@ -6,6 +6,7 @@
  * @typedef {import('micromark-util-types').Handle} Handle
  * @typedef {import('micromark-util-types').HtmlExtension} HtmlExtension
  * @typedef {import('micromark-util-types').Extension} Extension
+ * @typedef {import('micromark-util-types').CompileContext} CompileContext
  */
 
 import test from 'tape'
@@ -291,7 +292,6 @@ function tokenizeJustALessThan(effects, ok, nok) {
 
 /**
  * @this {CompileContext}
- * @type {Handle}
  */
 function enterComment() {
   this.buffer()
@@ -299,7 +299,6 @@ function enterComment() {
 
 /**
  * @this {CompileContext}
- * @type {Handle}
  */
 function exitComment() {
   this.resume()
@@ -308,7 +307,6 @@ function exitComment() {
 
 /**
  * @this {CompileContext}
- * @type {Handle}
  */
 function enterDocument() {
   this.raw('+')
@@ -316,7 +314,6 @@ function enterDocument() {
 
 /**
  * @this {CompileContext}
- * @type {Handle}
  */
 function exitDocument() {
   this.raw('-')

--- a/test/extension.js
+++ b/test/extension.js
@@ -141,7 +141,10 @@ test('html extension', function (t) {
 function createFunkyThematicBreak(marker) {
   return {tokenize: tokenizeFunkyThematicBreak}
 
-  /** @type {Tokenizer} */
+  /**
+   * @this {TokenizeContext}
+   * @type {Tokenizer}
+   */
   function tokenizeFunkyThematicBreak(effects, ok, nok) {
     let size = 0
 
@@ -208,7 +211,10 @@ function createFunkyThematicBreak(marker) {
   }
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeCommentLine(effects, ok, nok) {
   return start
 
@@ -263,7 +269,10 @@ function tokenizeCommentLine(effects, ok, nok) {
   }
 }
 
-/** @type {Tokenizer} */
+/**
+ * @this {TokenizeContext}
+ * @type {Tokenizer}
+ */
 function tokenizeJustALessThan(effects, ok, nok) {
   return start
 

--- a/test/extension.js
+++ b/test/extension.js
@@ -280,23 +280,35 @@ function tokenizeJustALessThan(effects, ok, nok) {
   }
 }
 
-/** @type {Handle} */
+/**
+ * @this {CompileContext}
+ * @type {Handle}
+ */
 function enterComment() {
   this.buffer()
 }
 
-/** @type {Handle} */
+/**
+ * @this {CompileContext}
+ * @type {Handle}
+ */
 function exitComment() {
   this.resume()
   this.setData('slurpOneLineEnding', true)
 }
 
-/** @type {Handle} */
+/**
+ * @this {CompileContext}
+ * @type {Handle}
+ */
 function enterDocument() {
   this.raw('+')
 }
 
-/** @type {Handle} */
+/**
+ * @this {CompileContext}
+ * @type {Handle}
+ */
 function exitDocument() {
   this.raw('-')
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,12 @@
 {
   "include": ["script/**/*.js", "test/**/*.js"],
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["ES2020"],
-    "module": "ES2020",
-    "moduleResolution": "node",
-    "allowJs": true,
+    "target": "es2021",
+    "lib": ["es2021"],
+    "module": "node16",
     "checkJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "strict": true
   }


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This includes:
- [x] TypeScript 4.9 fixes
- [x] Internal fixes TypeScript ESM resolution in Node16 mode
- [x] New conditional exports for TypeScript ESM


<!--do not edit: pr-->
