### PR TITLE
Update `rollup` to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   ],
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.0",
-    "@rollup/plugin-terser": "^0.3.0",
+    "@rollup/plugin-terser": "^0.4.0",
     "@types/concat-stream": "^2.0.0",
     "@types/glob": "^8.0.0",
     "@types/ms": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "packages/micromark"
   ],
   "devDependencies": {
-    "@rollup/plugin-node-resolve": "^14.0.0",
+    "@rollup/plugin-node-resolve": "^15.0.0",
+    "@rollup/plugin-terser": "^0.3.0",
     "@types/concat-stream": "^2.0.0",
     "@types/glob": "^8.0.0",
     "@types/ms": "^0.7.0",
@@ -78,8 +79,7 @@
     "remark-cli": "^11.0.0",
     "remark-preset-wooorm": "^9.0.0",
     "rimraf": "^3.0.0",
-    "rollup": "^2.0.0",
-    "rollup-plugin-terser": "^7.0.0",
+    "rollup": "^3.0.0",
     "tape": "^5.0.0",
     "type-coverage": "^2.0.0",
     "typescript": "^4.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,5 @@
 import {nodeResolve} from '@rollup/plugin-node-resolve'
-import {terser} from 'rollup-plugin-terser'
+import {terser} from '@rollup/plugin-terser'
 
 const configs = [
   {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,5 @@
 import {nodeResolve} from '@rollup/plugin-node-resolve'
-import {terser} from '@rollup/plugin-terser'
+import terser from '@rollup/plugin-terser'
 
 const configs = [
   {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

rollup 3 uses @types/estree 1+ which resolves a number of library eslint warnings currently triggered by pinning 0.x

Changelog: https://github.com/rollup/rollup/blob/master/CHANGELOG.md#300

We already use Node 14+.
Rollup using `node:` protocol imports sounds like an improvement.
Configuration changes look like options we're not using.

<!--do not edit: pr-->
