### PR TITLE
Fix exception in internal `sliceSerialize` API

### DIFF
--- a/packages/micromark/dev/lib/create-tokenizer.js
+++ b/packages/micromark/dev/lib/create-tokenizer.js
@@ -572,8 +572,13 @@ function sliceChunks(chunks, token) {
     view = chunks.slice(startIndex, endIndex)
 
     if (startBufferIndex > -1) {
-      // @ts-expect-error `_bufferIndex` is used on string chunks.
-      view[0] = view[0].slice(startBufferIndex)
+      const head = view[0]
+      if (typeof head === 'string') {
+        view[0] = head.slice(startBufferIndex)
+      } else {
+        assert(startBufferIndex === 0, 'expected `startBufferIndex` to be `0`')
+        view.shift()
+      }
     }
 
     if (endBufferIndex > 0) {

--- a/test/misc/index.js
+++ b/test/misc/index.js
@@ -1,2 +1,3 @@
 import './chunked-splice.js'
 import './decode-string.js'
+import './slice-chunks.js'

--- a/test/misc/slice-chunks.js
+++ b/test/misc/slice-chunks.js
@@ -1,0 +1,71 @@
+import test from 'tape'
+import {parse} from 'micromark/lib/parse'
+import {postprocess} from 'micromark/lib/postprocess'
+import {preprocess} from 'micromark/lib/preprocess'
+
+test('sliceSerialize', (t) => {
+  t.deepEqual(
+    parseAndSlice('Heading\n======='),
+    [
+      ['enter', 'setextHeading', 'Heading\n======='],
+      ['enter', 'setextHeadingText', 'Heading'],
+      ['enter', 'data', 'Heading'],
+      ['exit', 'data', 'Heading'],
+      ['exit', 'setextHeadingText', 'Heading'],
+      ['enter', 'lineEnding', '\n'],
+      ['exit', 'lineEnding', '\n'],
+      ['enter', 'setextHeadingLine', '======='],
+      ['enter', 'setextHeadingLineSequence', '======='],
+      ['exit', 'setextHeadingLineSequence', '======='],
+      ['exit', 'setextHeadingLine', '======='],
+      ['exit', 'setextHeading', 'Heading\n=======']
+    ],
+    'should support `sliceSerialize` on a setext heading (#1)'
+  )
+
+  // This used to crash: <https://github.com/micromark/micromark/issues/131>.
+  t.deepEqual(
+    parseAndSlice('\nHeading\n======='),
+    [
+      ['enter', 'lineEndingBlank', '\n'],
+      ['exit', 'lineEndingBlank', '\n'],
+      ['enter', 'setextHeading', 'Heading\n======='],
+      ['enter', 'setextHeadingText', 'Heading'],
+      ['enter', 'data', 'Heading'],
+      ['exit', 'data', 'Heading'],
+      ['exit', 'setextHeadingText', 'Heading'],
+      ['enter', 'lineEnding', '\n'],
+      ['exit', 'lineEnding', '\n'],
+      ['enter', 'setextHeadingLine', '======='],
+      ['enter', 'setextHeadingLineSequence', '======='],
+      ['exit', 'setextHeadingLineSequence', '======='],
+      ['exit', 'setextHeadingLine', '======='],
+      ['exit', 'setextHeading', 'Heading\n=======']
+    ],
+    'should support `sliceSerialize` on a setext heading (#2)'
+  )
+
+  t.end()
+})
+
+/**
+ * Parse `value`, get all events, call `context.sliceSerialize` on each token.
+ *
+ * @param {string} value
+ *   Input.
+ * @returns {Array<[string, string, string]>}
+ *   List of event kind, token names, and serialized slices.
+ */
+function parseAndSlice(value) {
+  const chunks = preprocess()(value, undefined, true)
+  const events = postprocess(parse().document().write(chunks))
+  /** @type {Array<[string, string, string]>} */
+  const result = []
+
+  for (const event of events) {
+    const [kind, token, context] = event
+    result.push([kind, token.type, context.sliceSerialize(token)])
+  }
+
+  return result
+}


### PR DESCRIPTION
Closes GH-131.

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Fixes a problem where TokenizeContext.sliceSerialize throws in sliceChunks if the first chunk of token is Code instead of string. See #131 for discussion. All code here was written by @wooorm.

<!--do not edit: pr-->
