### PR TITLE
Refactor to improve performance of `now`

### DIFF
--- a/packages/micromark/dev/lib/create-tokenizer.js
+++ b/packages/micromark/dev/lib/create-tokenizer.js
@@ -152,7 +152,9 @@ export function createTokenizer(parser, initialize, from) {
 
   /** @type {TokenizeContext['now']} */
   function now() {
-    return Object.assign({}, point)
+    // This is a hot path, so we clone manually instead of `Object.assign({}, point)`
+    const {line, column, offset, _index, _bufferIndex} = point
+    return {line, column, offset, _index, _bufferIndex}
   }
 
   /** @type {TokenizeContext['defineSkip']} */

--- a/test/perf.js
+++ b/test/perf.js
@@ -1,5 +1,8 @@
+import {readFile} from 'node:fs/promises'
 import ms from 'ms'
 import {micromark} from 'micromark'
+
+const readme = await readFile('readme.md', 'utf8')
 
 console.log('base')
 let then = Date.now()
@@ -29,4 +32,12 @@ console.log(ms(Date.now() - then))
 console.log('tons of definitions')
 then = Date.now()
 micromark('[a]: u\n'.repeat(1e4))
+console.log(ms(Date.now() - then))
+
+console.log('readme x1000')
+then = Date.now()
+for (let i = 0; i < 1000; i++) {
+  micromark(readme)
+}
+
 console.log(ms(Date.now() - then))


### PR DESCRIPTION
Closes GH-139.

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Manually implement `Object.assign` in `TokenizeContext.now` API for an approximate 11% reduction in execution time.

<!--do not edit: pr-->
