### PR TITLE
micromark-util-character: fix crash on some Node.js versions

### DIFF
--- a/packages/micromark-util-character/dev/index.js
+++ b/packages/micromark-util-character/dev/index.js
@@ -4,7 +4,8 @@
 
 import {codes} from 'micromark-util-symbol'
 
-const unicodePunctuationInternal = regexCheck(/\p{P}/u)
+// Lazy-load that regex to avoid crashing on Node.js compiled without Unicode support.
+let unicodePunctuationInternal
 
 /**
  * Check whether the character code represents an ASCII alpha (`a` through `z`,
@@ -206,7 +207,7 @@ export function markdownSpace(code) {
  *   Whether it matches.
  */
 export function unicodePunctuation(code) {
-  return asciiPunctuation(code) || unicodePunctuationInternal(code)
+  return asciiPunctuation(code) || (unicodePunctuationInternal ??= regexCheck(/\p{P}/u))(code)
 }
 
 /**


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

`\p` regex notation is not available on Node.js build without intl support, causing the process to crash even the regex is never used. Ideally we would have a regex that works everywhere, but I figure lazy-loading the same regex should be enough for most use-cases.

Refs: https://github.com/nodejs/node/pull/49988#issuecomment-1781469110

<!--do not edit: pr-->
