### PR TITLE
Fix handling of astral character reference

### DIFF
--- a/packages/micromark-util-decode-numeric-character-reference/dev/index.js
+++ b/packages/micromark-util-decode-numeric-character-reference/dev/index.js
@@ -38,5 +38,5 @@ export function decodeNumericCharacterReference(value, base) {
     return values.replacementCharacter
   }
 
-  return String.fromCharCode(code)
+  return String.fromCodePoint(code)
 }

--- a/packages/micromark-util-decode-numeric-character-reference/dev/index.js
+++ b/packages/micromark-util-decode-numeric-character-reference/dev/index.js
@@ -4,7 +4,7 @@ import {codes, values} from 'micromark-util-symbol'
  * Turn the number (in string form as either hexa- or plain decimal) coming from
  * a numeric character reference into a character.
  *
- * Sort of like `String.fromCharCode(Number.parseInt(value, base))`, but makes
+ * Sort of like `String.fromCodePoint(Number.parseInt(value, base))`, but makes
  * non-characters and control characters safe.
  *
  * @param {string} value

--- a/packages/micromark-util-decode-numeric-character-reference/readme.md
+++ b/packages/micromark-util-decode-numeric-character-reference/readme.md
@@ -78,7 +78,7 @@ There is no default export.
 Turn the number (in string form as either hexa- or plain decimal) coming from
 a numeric character reference into a character.
 
-Sort of like `String.fromCharCode(Number.parseInt(value, base))`, but makes
+Sort of like `String.fromCodePoint(Number.parseInt(value, base))`, but makes
 non-characters and control characters safe.
 
 ###### Parameters

--- a/test/io/text/character-reference.js
+++ b/test/io/text/character-reference.js
@@ -28,6 +28,12 @@ test('character-reference', function () {
   )
 
   assert.equal(
+    micromark('片&#xE0103;'),
+    '<p>片\u{E0103}</p>',
+    'should support astral character references'
+  )
+
+  assert.equal(
     micromark(
       [
         '&nbsp &x; &#; &#x;',


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

`decodeNumericCharacterReference` was using `String.fromCharCode` which only handles UTF-16 code units, not true codepoints. Any characters not representable by a single UTF-16 code unit ("astral characters") would come out incorrectly.

Note that there are other uses of `String.fromCharCode` in micromark. These should also be examined. The current behaviour is a regression that was introduced 4 months ago by bbb726d240ab8736daf5276555d17a6292e43dae, although the correct version only existed for 3 days prior to that 🙂 — the very first version of the function had the same problem.

<!--do not edit: pr-->
