### PR TITLE
Fix email autolink starting w/ `@`

### DIFF
--- a/packages/micromark-core-commonmark/dev/lib/autolink.js
+++ b/packages/micromark-core-commonmark/dev/lib/autolink.js
@@ -66,6 +66,10 @@ function tokenizeAutolink(effects, ok, nok) {
       return schemeOrEmailAtext
     }
 
+    if (code === codes.atSign) {
+      return nok(code)
+    }
+
     return emailAtext(code)
   }
 

--- a/test/io/text/autolink.js
+++ b/test/io/text/autolink.js
@@ -235,6 +235,12 @@ test('autolink', function () {
   )
 
   assert.equal(
+    micromark('<@example.com>'),
+    '<p>&lt;@example.com&gt;</p>',
+    'should not support an at sign at the start of email autolinks'
+  )
+
+  assert.equal(
     micromark('<a@b.co>', {extensions: [{disable: {null: ['autolink']}}]}),
     '<p>&lt;a@b.co&gt;</p>',
     'should support turning off autolinks'


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

The CommonMark spec defines an [email autolink](https://spec.commonmark.org/0.31.2/#email-autolink) as an email that follows [non-normative regex from the HTML5 spec](https://html.spec.whatwg.org/multipage/forms.html#e-mail-state-(type=email)) encased in `< >`.

This means that `<@example.com>` should not be autolinked as `@example.com` is not a valid email address.

https://spec.commonmark.org/dingus/?text=%3C%40example.com%3E%0A

<!--do not edit: pr-->
