### PR TITLE
Fix `micromark-build` in `dev` folders

### DIFF
--- a/packages/micromark-build/index.js
+++ b/packages/micromark-build/index.js
@@ -19,7 +19,7 @@ let index = -1
 
 while (++index < files.length) {
   const input = new URL(files[index], root + '/')
-  const output = new URL(input.href.replace(/\/dev\//, '/'))
+  const output = new URL(input.href.replace(/\/dev\/(?!.*\/dev\/)/, '/'))
   const inputRelative = RelativizeUrl.relativize(input, root)
   const outputRelative = RelativizeUrl.relativize(output, root)
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

**Problem:** Cloning micromark (main branch) into `~/dev/` (or any path containing `/dev/`) and running `npm install && npm run build` fails with `Cannot find module...`.

**Cause:** micromark-build replaces the first occurrence of `/dev/` in the full file path instead of the last occurrence when moving `.js` files up a directory.

**Proposed Solution:** This PR adds a negative lookahead to the regular expression in `.replace` so that the **last** occurrence of `/dev/` is replaced correctly.

<!--do not edit: pr-->
