### PR TITLE
Nested list items are incorrectly parsed

### DIFF
--- a/test/io/document/list-item.js
+++ b/test/io/document/list-item.js
@@ -18,6 +18,30 @@ test('list-item', function () {
   )
 
   assert.equal(
+    micromark('1. a\n\n    * b'),
+    '<ol>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ol>',
+    'should not misidentify documents in list items (1) (correct)'
+  )
+
+  assert.equal(
+    micromark('1.   a\n\n    * b'),
+    '<ol>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ol>',
+    'should not misidentify documents in list items (1)'
+  )
+
+  assert.equal(
+    micromark('10.  a\n\n    * b'),
+    '<ol start="10">\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ol>',
+    'should not misidentify documents in list items (2)'
+  )
+
+  assert.equal(
+    micromark('100. a\n\n    * b'),
+    '<ol start="100">\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ol>',
+    'should not misidentify documents in list items (3)'
+  )
+
+  assert.equal(
     micromark('- one\n\n two'),
     '<ul>\n<li>one</li>\n</ul>\n<p>two</p>',
     'should not support 1 space for a two-character list prefix'


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This adds a test that checks for `code` blocks that seem to be incorrectly placed in list items.

When the first letter in a list item starts before the 4th position, the html is generated correctly.
```markdown
1. a
 
    * b
```
generates
```html
<ol>
  <li>
    <p>a</p>
    <ul>
      <li>b</li>
    </ul>
  </li>
</ol>
```

But, if the first letter starts at the 4th position, you get a code block.

```markdown
1.   a
 
    * b
```
generates
```html
<ol>
    <li>a</li>
</ol>
<pre><code>* b
    
</code></pre>
```

<!--do not edit: pr-->
