### PR TITLE
Refactor to improve resolveAllLabelEnd performance

### DIFF
--- a/packages/micromark-core-commonmark/dev/lib/label-end.js
+++ b/packages/micromark-core-commonmark/dev/lib/label-end.js
@@ -43,11 +43,7 @@ function resolveAllLabelEnd(events) {
   const newEvents = []
   while (++index < events.length) {
     const token = events[index][1]
-    if (newEvents.length > 0) {
-      push(newEvents, [events[index]])
-    } else {
-      newEvents.push(events[index])
-    }
+    newEvents.push(events[index])
 
     if (
       token.type === types.labelImage ||
@@ -57,15 +53,15 @@ function resolveAllLabelEnd(events) {
       // Remove the marker.
       const offset = token.type === types.labelImage ? 4 : 2
       token.type = types.data
-      // Exit effect can skip the check
-      index += offset + 1
-      if (index < events.length) {
-        push(newEvents, [events[index]])
-      }
+      index += offset
     }
   }
 
-  splice(events, 0, events.length, newEvents)
+  // If the events are equal, we don't have to copy newEvents to events
+  if (events.length !== newEvents.length) {
+    splice(events, 0, events.length, newEvents)
+  }
+
   return events
 }
 

--- a/packages/micromark-core-commonmark/dev/lib/label-end.js
+++ b/packages/micromark-core-commonmark/dev/lib/label-end.js
@@ -39,9 +39,15 @@ const referenceCollapsedConstruct = {tokenize: tokenizeReferenceCollapsed}
 /** @type {Resolver} */
 function resolveAllLabelEnd(events) {
   let index = -1
-
+  /** @type {Array<Event>} */
+  const newEvents = []
   while (++index < events.length) {
     const token = events[index][1]
+    if (newEvents.length > 0) {
+      push(newEvents, [events[index]])
+    } else {
+      newEvents.push(events[index])
+    }
 
     if (
       token.type === types.labelImage ||
@@ -49,12 +55,17 @@ function resolveAllLabelEnd(events) {
       token.type === types.labelEnd
     ) {
       // Remove the marker.
-      events.splice(index + 1, token.type === types.labelImage ? 4 : 2)
+      const offset = token.type === types.labelImage ? 4 : 2
       token.type = types.data
-      index++
+      // Exit effect can skip the check
+      index += offset + 1
+      if (index < events.length) {
+        push(newEvents, [events[index]])
+      }
     }
   }
 
+  splice(events, 0, events.length, newEvents)
   return events
 }
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

I use the Unified ecosystem to compile Markdown strings in my service. Recently, I encountered a serious performance issue when the input string contains a large number of '[]' patterns. After profiling the problematic input, I found that the majority of time consumption occurs in this function: https://github.com/micromark/micromark/blob/main/packages/micromark-core-commonmark/dev/lib/label-end.js#L40-L59.

The issue arises because the input string contains many '[]' sequences, which triggers repeated array splicing in the events array, leading to significant performance overhead.

To address this, I attempted to optimize the function by removing the use of splice and instead creating a new array. While this approach might be slower in scenarios where the main logic is not heavily utilized, it significantly reduces compilation time when processing Markdown strings with numerous '[]' patterns.

You can see my research and results here: https://github.com/PerfectPan/micromark-label-end-performance. With this optimization, the processing time for a Markdown string containing 10,000 instances of '[]' was reduced from 500ms to just 3ms.

<!--do not edit: pr-->
