### PR TITLE
Recognize supplementary (non-BMP) punctuation & symbols

### DIFF
--- a/packages/micromark-core-commonmark/dev/lib/attention.js
+++ b/packages/micromark-core-commonmark/dev/lib/attention.js
@@ -209,7 +209,25 @@ function resolveAllAttention(events, context) {
  */
 function tokenizeAttention(effects, ok) {
   const attentionMarkers = this.parser.constructs.attentionMarkers.null
-  const previous = this.previous
+  let previous = this.previous
+  const {now, sliceSerialize} = this
+  // second (lower) surrogate likely to be preceded by first (higher) surrogate
+  if (previous && previous >= 0xdc_00 && previous <= 0xdf_ff) {
+    const nowPoint = now() // @ first attention marker
+    if (nowPoint._bufferIndex >= 2) {
+      const previousBuffer = sliceSerialize({
+        // take 2 characters
+        start: {...nowPoint, _bufferIndex: nowPoint._bufferIndex - 2},
+        end: nowPoint
+      })
+      const previousCandidate = previousBuffer.codePointAt(0)
+      // possibly undefined or non-surrogate (=lonely surrogate), so we have to make sure not
+      if (previousCandidate && previousCandidate >= 65_536) {
+        previous = previousCandidate
+      }
+    }
+  }
+
   const before = classifyCharacter(previous)
 
   /** @type {NonNullable<Code>} */
@@ -255,8 +273,21 @@ function tokenizeAttention(effects, ok) {
 
     const token = effects.exit('attentionSequence')
 
-    // To do: next major: move this to resolver, just like `markdown-rs`.
-    const after = classifyCharacter(code)
+    // To do: next major: move these to resolver, just like `markdown-rs`.
+    let next = code
+    // possibly first (lower) surrogate
+    if (next && next >= 0xd8_00 && next <= 0xdf_ff) {
+      const nowPoint = now() // @ first character next to attention marker
+      const nextCandidate = sliceSerialize({
+        start: nowPoint,
+        end: {...nowPoint, _bufferIndex: nowPoint._bufferIndex + 2}
+      }).codePointAt(0)
+      if (nextCandidate && nextCandidate >= 65_536) {
+        next = nextCandidate
+      }
+    }
+
+    const after = classifyCharacter(next)
 
     // Always populated by defaults.
     assert(attentionMarkers, 'expected `attentionMarkers` to be populated')

--- a/packages/micromark-core-commonmark/dev/lib/attention.js
+++ b/packages/micromark-core-commonmark/dev/lib/attention.js
@@ -211,17 +211,17 @@ function tokenizeAttention(effects, ok) {
   const attentionMarkers = this.parser.constructs.attentionMarkers.null
   let previous = this.previous
   const {now, sliceSerialize} = this
-  // second (lower) surrogate likely to be preceded by first (higher) surrogate
+  // Second (lower) surrogate likely to be preceded by first (higher) surrogate
   if (previous && previous >= 0xdc_00 && previous <= 0xdf_ff) {
     const nowPoint = now() // @ first attention marker
     if (nowPoint._bufferIndex >= 2) {
       const previousBuffer = sliceSerialize({
-        // take 2 characters
+        // Take 2 characters
         start: {...nowPoint, _bufferIndex: nowPoint._bufferIndex - 2},
         end: nowPoint
       })
       const previousCandidate = previousBuffer.codePointAt(0)
-      // possibly undefined or non-surrogate (=lonely surrogate), so we have to make sure not
+      // Possibly undefined or non-surrogate (=lonely surrogate), so we have to make sure not
       if (previousCandidate && previousCandidate >= 65_536) {
         previous = previousCandidate
       }
@@ -275,7 +275,7 @@ function tokenizeAttention(effects, ok) {
 
     // To do: next major: move these to resolver, just like `markdown-rs`.
     let next = code
-    // possibly first (lower) surrogate
+    // Possibly first (lower) surrogate
     if (next && next >= 0xd8_00 && next <= 0xdf_ff) {
       const nowPoint = now() // @ first character next to attention marker
       const nextCandidate = sliceSerialize({

--- a/packages/micromark-core-commonmark/dev/lib/attention.js
+++ b/packages/micromark-core-commonmark/dev/lib/attention.js
@@ -211,17 +211,17 @@ function tokenizeAttention(effects, ok) {
   const attentionMarkers = this.parser.constructs.attentionMarkers.null
   let previous = this.previous
   const {now, sliceSerialize} = this
-  // Second (lower) surrogate likely to be preceded by first (higher) surrogate
+  // Second (lower) surrogate code unit likely to be preceded by first (higher) surrogate code unit
   if (previous && previous >= 0xdc_00 && previous <= 0xdf_ff) {
     const nowPoint = now() // @ first attention marker
     if (nowPoint._bufferIndex >= 2) {
       const previousBuffer = sliceSerialize({
-        // Take 2 characters
+        // Take 2 code units
         start: {...nowPoint, _bufferIndex: nowPoint._bufferIndex - 2},
         end: nowPoint
       })
       const previousCandidate = previousBuffer.codePointAt(0)
-      // Possibly undefined or non-surrogate (=lonely surrogate), so we have to make sure not
+      // Possibly undefined or not surrogate pair (i.e. isolated surrogate code unit), so we have to make sure not
       if (previousCandidate && previousCandidate >= 65_536) {
         previous = previousCandidate
       }
@@ -275,9 +275,9 @@ function tokenizeAttention(effects, ok) {
 
     // To do: next major: move these to resolver, just like `markdown-rs`.
     let next = code
-    // Possibly first (lower) surrogate
+    // Possibly first (lower) surrogate code unit
     if (next && next >= 0xd8_00 && next <= 0xdf_ff) {
-      const nowPoint = now() // @ first character next to attention marker
+      const nowPoint = now() // @ first code unit next to attention marker
       const nextCandidate = sliceSerialize({
         start: nowPoint,
         end: {...nowPoint, _bufferIndex: nowPoint._bufferIndex + 2}

--- a/packages/micromark-util-character/dev/index.js
+++ b/packages/micromark-util-character/dev/index.js
@@ -205,6 +205,7 @@ export function markdownSpace(code) {
  */
 export const unicodePunctuation = regexCheck(/\p{P}|\p{S}/u)
 
+// no Unicode whitespace outside of BMP; Surrogate has its own category Cs
 /**
  * Check whether the character code represents Unicode whitespace.
  *
@@ -247,6 +248,6 @@ function regexCheck(regex) {
    *   Whether the character code matches the bound regex.
    */
   function check(code) {
-    return code !== null && code > -1 && regex.test(String.fromCharCode(code))
+    return code !== null && code > -1 && regex.test(String.fromCodePoint(code))
   }
 }

--- a/packages/micromark-util-character/dev/index.js
+++ b/packages/micromark-util-character/dev/index.js
@@ -205,7 +205,7 @@ export function markdownSpace(code) {
  */
 export const unicodePunctuation = regexCheck(/\p{P}|\p{S}/u)
 
-// no Unicode whitespace outside of BMP; Surrogate has its own category Cs
+// No Unicode whitespace outside of BMP; Surrogate has its own category Cs
 /**
  * Check whether the character code represents Unicode whitespace.
  *

--- a/packages/micromark-util-character/dev/index.js
+++ b/packages/micromark-util-character/dev/index.js
@@ -205,7 +205,7 @@ export function markdownSpace(code) {
  */
 export const unicodePunctuation = regexCheck(/\p{P}|\p{S}/u)
 
-// No Unicode whitespace outside of BMP; Surrogate has its own category Cs
+// No Unicode whitespace outside of BMP; Surrogate code points have its own category Cs
 /**
  * Check whether the character code represents Unicode whitespace.
  *

--- a/test/io/text/emphasis.js
+++ b/test/io/text/emphasis.js
@@ -1003,7 +1003,7 @@ test('emphasis', async function (t) {
   })
 
   await t.test(
-    'should recognize non-BMP punctuation & symbols (1)',
+    'should recognize supplementary (non-BMP) punctuation & symbols (1)',
     async function () {
       assert.equal(
         micromark('a*a𝜵*a\n\na*𝜵a*a\n\na*𐬻a*a\n\na*a𐬻*a'),
@@ -1013,7 +1013,7 @@ test('emphasis', async function (t) {
   )
 
   await t.test(
-    'should recognize non-BMP punctuation & symbols (2)',
+    'should recognize supplementary (non-BMP) punctuation & symbols (2)',
     async function () {
       assert.equal(
         micromark('a**a𝜵**a\n\na**𝜵a**a\n\na**𐬻a**a\n\na**a𐬻**a'),
@@ -1023,12 +1023,9 @@ test('emphasis', async function (t) {
   )
 
   await t.test(
-    'Should handle lonely surrogate pair around emphasis',
+    'Should not throw even when input has isolated surrogate code units',
     async function () {
-      assert.equal(
-        micromark('\uDC00*\uD800\n\na\uDBFF*\uDFFFa'),
-        '<p>\uDC00*\uD800</p>\n<p>a\uDBFF*\uDFFFa</p>'
-      )
+      micromark('\uDC00*\uD800\n\na\uDBFF*\uDFFFa')
     }
   )
 })

--- a/test/io/text/emphasis.js
+++ b/test/io/text/emphasis.js
@@ -1023,9 +1023,12 @@ test('emphasis', async function (t) {
   )
 
   await t.test(
-    'Should not throw even when input has isolated surrogate code units',
+    'Should not throw even when input has isolated surrogate code units and still return a string',
     async function () {
-      micromark('\uDC00*\uD800\n\na\uDBFF*\uDFFFa')
+      assert.equal(
+        typeof micromark('\uDC00*\uD800\n\na\uDBFF*\uDFFFa'),
+        'string'
+      )
     }
   )
 })

--- a/test/io/text/emphasis.js
+++ b/test/io/text/emphasis.js
@@ -1001,4 +1001,34 @@ test('emphasis', async function (t) {
       '<p>*a*</p>'
     )
   })
+
+  await t.test(
+    'should recognize non-BMP punctuation & symbols (1)',
+    async function () {
+      assert.equal(
+        micromark('a*a𝜵*a\n\na*𝜵a*a\n\na*𐬻a*a\n\na*a𐬻*a'),
+        '<p>a*a𝜵*a</p>\n<p>a*𝜵a*a</p>\n<p>a*𐬻a*a</p>\n<p>a*a𐬻*a</p>'
+      )
+    }
+  )
+
+  await t.test(
+    'should recognize non-BMP punctuation & symbols (2)',
+    async function () {
+      assert.equal(
+        micromark('a**a𝜵**a\n\na**𝜵a**a\n\na**𐬻a**a\n\na**a𐬻**a'),
+        '<p>a**a𝜵**a</p>\n<p>a**𝜵a**a</p>\n<p>a**𐬻a**a</p>\n<p>a**a𐬻**a</p>'
+      )
+    }
+  )
+
+  await t.test(
+    'Should handle lonely surrogate pair around emphasis',
+    async function () {
+      assert.equal(
+        micromark('\uDC00*\uD800\n\na\uDBFF*\uDFFFa'),
+        '<p>\uDC00*\uD800</p>\n<p>a\uDBFF*\uDFFFa</p>'
+      )
+    }
+  )
 })


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amicromark&type=issues and https://github.com/orgs/micromark/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Fixes #189 
We might need more tests to deal with abnormal surrogate pair patterns.

<!--do not edit: pr-->
