### PR TITLE
Fix type error of Stream.Writable.write

### DIFF
--- a/test/util/slow-stream.js
+++ b/test/util/slow-stream.js
@@ -20,7 +20,7 @@ export function slowStream(value, encoding) {
     if (index === value.length) {
       stream.end()
     } else {
-      stream.write(value.slice(index, ++index), encoding ?? 'utf8', tick)
+      stream.write(value.slice(index, ++index), encoding || 'utf8', tick)
     }
   }
 

--- a/test/util/slow-stream.js
+++ b/test/util/slow-stream.js
@@ -20,7 +20,7 @@ export function slowStream(value, encoding) {
     if (index === value.length) {
       stream.end()
     } else {
-      stream.write(value.slice(index, ++index), encoding, tick)
+      stream.write(value.slice(index, ++index), encoding ?? 'utf8', tick)
     }
   }
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amicromark&type=issues and https://github.com/orgs/micromark/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

If you remove `node_modules` and re-run `npm install`, `npm run build` will fail due to the fact that the signature of `Stream.Writable.write` has been changed and that change caused a type error of TypeScript.

https://nodejs.org/api/stream.html#writablewritechunk-encoding-callback

This change passes the default value `"utf8"` to supress the type error.

<!--do not edit: pr-->
