### PR TITLE
fix(docs): mdast-util-from-markdown does not export a default

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1154,7 +1154,7 @@ A higher level project, [`mdast-util-from-markdown`][mdast-util-from-markdown],
 can give you an AST.
 
 ```js
-import { fromMarkdown } from 'mdast-util-from-markdown' // This wraps micromark.
+import {fromMarkdown} from 'mdast-util-from-markdown' // This wraps micromark.
 
 const result = fromMarkdown('## Hello, *world*!')
 

--- a/readme.md
+++ b/readme.md
@@ -1154,7 +1154,7 @@ A higher level project, [`mdast-util-from-markdown`][mdast-util-from-markdown],
 can give you an AST.
 
 ```js
-import fromMarkdown from 'mdast-util-from-markdown' // This wraps micromark.
+import { fromMarkdown } from 'mdast-util-from-markdown' // This wraps micromark.
 
 const result = fromMarkdown('## Hello, *world*!')
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amicromark&type=issues and https://github.com/orgs/micromark/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes
`import fromMarkdown from 'mdast-util-from-markdown'` is not available as it has an error
Module '"node_modules/mdast-util-from-markdown/index"' has no default export


Change to
`import { fromMarkdown } from 'mdast-util-from-markdown'` fix that.

PR #198 closed by mistake
<!--do not edit: pr-->
