### PR TITLE
Restore CommonMark flanking rules for `*`, `_`

### DIFF
--- a/packages/micromark/dev/lib/constructs.js
+++ b/packages/micromark/dev/lib/constructs.js
@@ -95,7 +95,7 @@ export const text = {
 export const insideSpan = {null: [attention, resolveText]}
 
 /** @satisfies {Extension['attentionMarkers']} */
-export const attentionMarkers = {null: [codes.asterisk, codes.underscore]}
+export const attentionMarkers = {null: []}
 
 /** @satisfies {Extension['disable']} */
 export const disable = {null: []}

--- a/test/io/text/emphasis.js
+++ b/test/io/text/emphasis.js
@@ -23,6 +23,13 @@ test('emphasis', async function (t) {
   )
 
   await t.test(
+    'should not support emphasis if the opening is not left flanking (3)',
+    async function () {
+      assert.equal(micromark('a*_*'), '<p>a*_*</p>')
+    }
+  )
+
+  await t.test(
     'should not support emphasis unicode whitespace either',
     async function () {
       assert.equal(micromark('* a *'), '<p>* a *</p>')


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amicromark&type=issues and https://github.com/orgs/micromark/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Commit ca7f07546fd6dd1a7e6c88e21e4eca2f67e5100d introduced `attentionMarkers` as an extension point that overrides the CommonMark rules for left-flanking and right-flanking delimiter runs.  This override should be used for extra delimiters like GFM `~`, but not for the standard `*` and `_` delimeters, which should use the CommonMark rules already built in.

For example, `a*_*` should render to `<p>a*_*</p>`, not `<p>a<em>_</em></p>`.  Fixes #220.

<!--do not edit: pr-->
