### PR TITLE
Drop `debug` dependency

### DIFF
--- a/packages/micromark-build/index.js
+++ b/packages/micromark-build/index.js
@@ -17,11 +17,16 @@ import {resolve} from 'import-meta-resolve'
 import RelativizeUrl from 'relativize-url'
 
 const root = pathToFileURL(process.cwd())
+const debugConstantPath = pathToFileURL(
+  path.join(process.cwd(), 'dev/debug.js')
+)
 const files = await glob('./dev/**/*{.d.ts.map,.d.ts,.js}', {cwd: root})
 let index = -1
 
 while (++index < files.length) {
   const input = new URL(files[index], root + '/')
+  if (input.href === debugConstantPath.href) continue
+
   const output = new URL(input.href.replace(/\/dev\/(?!.*\/dev\/)/, '/'))
   const inputRelative = RelativizeUrl.relativize(input, root)
   const outputRelative = RelativizeUrl.relativize(output, root)
@@ -54,7 +59,13 @@ while (++index < files.length) {
     })
     .filter(Boolean)
 
-  const result = await babel(String(await fs.readFile(input)), {
+  // Check if ./debug.js file exists before inlining
+  try {
+    await fs.access(debugConstantPath)
+    modules.push(debugConstantPath.href)
+  } catch {}
+
+  const result = await babel(await fs.readFile(input, 'utf-8'), {
     filename: fileURLToPath(input),
     plugins: [
       [
@@ -70,8 +81,8 @@ while (++index < files.length) {
           ]
         }
       ],
-      removeDebugLog,
-      ['babel-plugin-inline-constants', {modules}]
+      ['babel-plugin-inline-constants', {modules}],
+      'babel-plugin-minify-dead-code-elimination'
     ]
   })
 
@@ -82,38 +93,4 @@ while (++index < files.length) {
   console.log('%s (from `%s`)', outputRelative, inputRelative)
 
   await fs.writeFile(output, result.code)
-}
-
-/**
- * @returns {PluginObj}
- */
-function removeDebugLog() {
-  const name = '$logDebug'
-
-  return {
-    name: 'remove-logdebug',
-    visitor: {
-      CallExpression(path) {
-        const callee = path.node.callee
-
-        // Remove `$logDebug()`.
-        if (t.isIdentifier(callee, {name})) {
-          path.remove()
-        } else if (
-          t.isMemberExpression(callee) &&
-          t.isIdentifier(callee.property, {name})
-        ) {
-          path.remove()
-        }
-      },
-      VariableDeclaration(path) {
-        if (
-          path.node.declarations.length === 1 &&
-          t.isIdentifier(path.node.declarations[0].id, {name})
-        ) {
-          path.remove()
-        }
-      }
-    }
-  }
 }

--- a/packages/micromark-build/index.js
+++ b/packages/micromark-build/index.js
@@ -90,24 +90,26 @@ while (++index < files.length) {
  *   Babel plugin.
  */
 function removeDebugLog({types: t}) {
+  const name = '$logDebug'
+
   return {
     name: 'remove-logdebug',
     visitor: {
       CallExpression(path) {
         const callee = path.node.callee
 
-        // Remove `logDebug()`.
-        if (t.isIdentifier(callee, {name: 'logDebug'})) {
+        // Remove `$logDebug()`.
+        if (t.isIdentifier(callee, {name})) {
           path.remove()
         } else if (
           t.isMemberExpression(callee) &&
-          t.isIdentifier(callee.property, {name: 'logDebug'})
+          t.isIdentifier(callee.property, {name})
         ) {
           path.remove()
         }
       },
       FunctionDeclaration(path) {
-        if (t.isIdentifier(path.node.id, {name: 'logDebug'})) {
+        if (t.isIdentifier(path.node.id, {name})) {
           path.remove()
         }
       }

--- a/packages/micromark-build/index.js
+++ b/packages/micromark-build/index.js
@@ -106,8 +106,11 @@ function removeDebugLog() {
           path.remove()
         }
       },
-      FunctionDeclaration(path) {
-        if (t.isIdentifier(path.node.id, {name})) {
+      VariableDeclaration(path) {
+        if (
+          path.node.declarations.length === 1 &&
+          t.isIdentifier(path.node.declarations[0].id, {name})
+        ) {
           path.remove()
         }
       }

--- a/packages/micromark-build/index.js
+++ b/packages/micromark-build/index.js
@@ -10,7 +10,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 import {fileURLToPath, pathToFileURL} from 'node:url'
-import {transformAsync as babel, types as t} from '@babel/core'
+import {transformAsync as babel} from '@babel/core'
 import {glob} from 'glob'
 import {resolve} from 'import-meta-resolve'
 // @ts-expect-error: untyped.

--- a/packages/micromark-build/index.js
+++ b/packages/micromark-build/index.js
@@ -67,7 +67,7 @@ while (++index < files.length) {
           ]
         }
       ],
-      'babel-plugin-undebug',
+      removeDebugLog,
       ['babel-plugin-inline-constants', {modules}]
     ]
   })
@@ -79,4 +79,38 @@ while (++index < files.length) {
   console.log('%s (from `%s`)', outputRelative, inputRelative)
 
   await fs.writeFile(output, result.code)
+}
+
+/**
+ *  @import {PluginObj} from '@babel/core'
+ *
+ * @param {{types: typeof import('@babel/core').types}} api
+ *   Babel API.
+ * @returns {PluginObj}
+ *   Babel plugin.
+ */
+function removeDebugLog({types: t}) {
+  return {
+    name: 'remove-logdebug',
+    visitor: {
+      CallExpression(path) {
+        const callee = path.node.callee
+
+        // Remove `logDebug()`.
+        if (t.isIdentifier(callee, {name: 'logDebug'})) {
+          path.remove()
+        } else if (
+          t.isMemberExpression(callee) &&
+          t.isIdentifier(callee.property, {name: 'logDebug'})
+        ) {
+          path.remove()
+        }
+      },
+      FunctionDeclaration(path) {
+        if (t.isIdentifier(path.node.id, {name: 'logDebug'})) {
+          path.remove()
+        }
+      }
+    }
+  }
 }

--- a/packages/micromark-build/index.js
+++ b/packages/micromark-build/index.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+/**
+ * @import {PluginObj} from '@babel/core'
+ */
 
 // A tiny CLI to get (`.d.ts` and) `.js` files from `dev/`, make them ready for
 // production, and place them a directory higher.
@@ -7,7 +10,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 import {fileURLToPath, pathToFileURL} from 'node:url'
-import {transformAsync as babel} from '@babel/core'
+import {transformAsync as babel, types as t} from '@babel/core'
 import {glob} from 'glob'
 import {resolve} from 'import-meta-resolve'
 // @ts-expect-error: untyped.
@@ -82,14 +85,9 @@ while (++index < files.length) {
 }
 
 /**
- *  @import {PluginObj} from '@babel/core'
- *
- * @param {{types: typeof import('@babel/core').types}} api
- *   Babel API.
  * @returns {PluginObj}
- *   Babel plugin.
  */
-function removeDebugLog({types: t}) {
+function removeDebugLog() {
   const name = '$logDebug'
 
   return {

--- a/packages/micromark-build/package.json
+++ b/packages/micromark-build/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@babel/core": "^7.0.0",
     "babel-plugin-inline-constants": "^5.0.0",
+    "babel-plugin-minify-dead-code-elimination": "^0.5.2",
     "babel-plugin-unassert": "^3.2.0",
     "glob": "^10.0.0",
     "import-meta-resolve": "^4.0.0",

--- a/packages/micromark-build/package.json
+++ b/packages/micromark-build/package.json
@@ -35,7 +35,6 @@
     "@babel/core": "^7.0.0",
     "babel-plugin-inline-constants": "^5.0.0",
     "babel-plugin-unassert": "^3.2.0",
-    "babel-plugin-undebug": "^3.0.0",
     "glob": "^10.0.0",
     "import-meta-resolve": "^4.0.0",
     "relativize-url": "^0.1.0"
@@ -49,5 +48,8 @@
       "no-await-in-loop": "off",
       "unicorn/prefer-code-point": "off"
     }
+  },
+  "devDependencies": {
+    "@types/babel__core": "^7.20.5"
   }
 }

--- a/packages/micromark/dev/debug.js
+++ b/packages/micromark/dev/debug.js
@@ -1,0 +1,25 @@
+/** @param {string} namespace */
+const isDebugFunction = (namespace) => {
+  if (typeof process !== 'undefined' && process.env.DEBUG) {
+    /** @type {string[]} */
+    const namespaces = process.env.DEBUG.trim().split(/\s+|,/g).filter(Boolean)
+
+    let v = false
+    for (const item of namespaces) {
+      switch (item) {
+        case '*':
+        case namespace:
+          v = true
+          break
+        case `-${namespace}`:
+          v = false
+          break
+      }
+    }
+    return v
+  }
+
+  return false
+}
+
+export const IS_DEBUG = isDebugFunction('micromark')

--- a/packages/micromark/dev/debug.js
+++ b/packages/micromark/dev/debug.js
@@ -1,3 +1,6 @@
+/* This code runs on both browser & server, the default require("process") rule will break under browser environments */
+/* eslint n/prefer-global/process: [error] */
+
 /** @param {string} namespace */
 const isDebugFunction = (namespace) => {
   if (typeof process !== 'undefined' && process.env.DEBUG) {
@@ -6,15 +9,8 @@ const isDebugFunction = (namespace) => {
 
     let v = false
     for (const item of namespaces) {
-      switch (item) {
-        case '*':
-        case namespace:
-          v = true
-          break
-        case `-${namespace}`:
-          v = false
-          break
-      }
+      if (item === '*' || item === namespace) v = true
+      else if (item === `-${namespace}`) v = false
     }
     return v
   }

--- a/packages/micromark/dev/lib/create-tokenizer.js
+++ b/packages/micromark/dev/lib/create-tokenizer.js
@@ -177,7 +177,7 @@ export function createTokenizer(parser, initialize, from) {
   function defineSkip(value) {
     columnStart[value.line] = value.column
     accountForPotentialSkip()
-    $logDebug(`position: define skip: ${JSON.stringify(point)}`)
+    $logDebug('position: define skip:', point)
   }
 
   //
@@ -233,7 +233,7 @@ export function createTokenizer(parser, initialize, from) {
   function go(code) {
     assert(consumed === true, 'expected character to be consumed')
     consumed = undefined
-    $logDebug(`main: passing ${code} to ${state && state.name}`)
+    $logDebug('main: passing', code, 'to', state && state.name)
     expectedCode = code
     assert(typeof state === 'function', 'expected state')
     state = state(code)
@@ -243,7 +243,7 @@ export function createTokenizer(parser, initialize, from) {
   function consume(code) {
     assert(code === expectedCode, 'expected given code to equal expected code')
 
-    $logDebug(`consume: ${code}`)
+    $logDebug('consume:', code)
 
     assert(
       consumed === undefined,
@@ -262,7 +262,7 @@ export function createTokenizer(parser, initialize, from) {
       point.column = 1
       point.offset += code === codes.carriageReturnLineFeed ? 2 : 1
       accountForPotentialSkip()
-      $logDebug(`position: after eol: ${point}`)
+      $logDebug('position: after eol:', point)
     } else if (code !== codes.virtualSpace) {
       point.column++
       point.offset++
@@ -303,7 +303,7 @@ export function createTokenizer(parser, initialize, from) {
 
     assert(typeof type === 'string', 'expected string type')
     assert(type.length > 0, 'expected non-empty string')
-    $logDebug(`enter: ${type}`)
+    $logDebug('enter:', type)
 
     context.events.push(['enter', token, context])
 
@@ -331,7 +331,7 @@ export function createTokenizer(parser, initialize, from) {
       'expected non-empty token (`' + type + '`)'
     )
 
-    $logDebug(`exit: ${token.type}`)
+    $logDebug('exit:', token.type)
     context.events.push(['exit', token, context])
 
     return token
@@ -577,7 +577,7 @@ export function createTokenizer(parser, initialize, from) {
       context.events.length = startEventsIndex
       stack = startStack
       accountForPotentialSkip()
-      $logDebug(`position: restore: ${JSON.stringify(point)}`)
+      $logDebug('position: restore:', point)
     }
   }
 
@@ -713,7 +713,7 @@ function serializeChunks(chunks, expandTabs) {
   return result.join('')
 }
 
-/** @param {string} v  */
-function $logDebug(v) {
-  console.log(`[micromark] ${v}`)
-}
+const $logDebug =
+  typeof process !== 'undefined' && process.env.DEBUG?.includes('micromark')
+    ? console.debug.bind(console, '[micromark]')
+    : () => {}

--- a/packages/micromark/dev/lib/create-tokenizer.js
+++ b/packages/micromark/dev/lib/create-tokenizer.js
@@ -37,14 +37,11 @@
  *   Nothing.
  */
 
-import createDebug from 'debug'
 import {ok as assert} from 'devlop'
 import {markdownLineEnding} from 'micromark-util-character'
 import {push, splice} from 'micromark-util-chunked'
 import {resolveAll} from 'micromark-util-resolve-all'
 import {codes, values} from 'micromark-util-symbol'
-
-const debug = createDebug('micromark')
 
 /**
  * Create a tokenizer.
@@ -180,7 +177,7 @@ export function createTokenizer(parser, initialize, from) {
   function defineSkip(value) {
     columnStart[value.line] = value.column
     accountForPotentialSkip()
-    debug('position: define skip: `%j`', point)
+    logDebug(`position: define skip: ${JSON.stringify(point)}`)
   }
 
   //
@@ -236,7 +233,7 @@ export function createTokenizer(parser, initialize, from) {
   function go(code) {
     assert(consumed === true, 'expected character to be consumed')
     consumed = undefined
-    debug('main: passing `%s` to %s', code, state && state.name)
+    logDebug(`main: passing ${code} to ${state && state.name}`)
     expectedCode = code
     assert(typeof state === 'function', 'expected state')
     state = state(code)
@@ -246,7 +243,7 @@ export function createTokenizer(parser, initialize, from) {
   function consume(code) {
     assert(code === expectedCode, 'expected given code to equal expected code')
 
-    debug('consume: `%s`', code)
+    logDebug(`consume: ${code}`)
 
     assert(
       consumed === undefined,
@@ -265,7 +262,7 @@ export function createTokenizer(parser, initialize, from) {
       point.column = 1
       point.offset += code === codes.carriageReturnLineFeed ? 2 : 1
       accountForPotentialSkip()
-      debug('position: after eol: `%j`', point)
+      logDebug(`position: after eol: ${point}`)
     } else if (code !== codes.virtualSpace) {
       point.column++
       point.offset++
@@ -306,7 +303,7 @@ export function createTokenizer(parser, initialize, from) {
 
     assert(typeof type === 'string', 'expected string type')
     assert(type.length > 0, 'expected non-empty string')
-    debug('enter: `%s`', type)
+    logDebug(`enter: ${type}`)
 
     context.events.push(['enter', token, context])
 
@@ -334,7 +331,7 @@ export function createTokenizer(parser, initialize, from) {
       'expected non-empty token (`' + type + '`)'
     )
 
-    debug('exit: `%s`', token.type)
+    logDebug(`exit: ${token.type}`)
     context.events.push(['exit', token, context])
 
     return token
@@ -580,7 +577,7 @@ export function createTokenizer(parser, initialize, from) {
       context.events.length = startEventsIndex
       stack = startStack
       accountForPotentialSkip()
-      debug('position: restore: `%j`', point)
+      logDebug(`position: restore: ${JSON.stringify(point)}`)
     }
   }
 
@@ -714,4 +711,11 @@ function serializeChunks(chunks, expandTabs) {
   }
 
   return result.join('')
+}
+
+/** @param {string} v  */
+function logDebug(v) {
+  if (process.env.mode === 'development') {
+    console.log(`[micromark] ${v}`)
+  }
 }

--- a/packages/micromark/dev/lib/create-tokenizer.js
+++ b/packages/micromark/dev/lib/create-tokenizer.js
@@ -177,7 +177,7 @@ export function createTokenizer(parser, initialize, from) {
   function defineSkip(value) {
     columnStart[value.line] = value.column
     accountForPotentialSkip()
-    logDebug(`position: define skip: ${JSON.stringify(point)}`)
+    $logDebug(`position: define skip: ${JSON.stringify(point)}`)
   }
 
   //
@@ -233,7 +233,7 @@ export function createTokenizer(parser, initialize, from) {
   function go(code) {
     assert(consumed === true, 'expected character to be consumed')
     consumed = undefined
-    logDebug(`main: passing ${code} to ${state && state.name}`)
+    $logDebug(`main: passing ${code} to ${state && state.name}`)
     expectedCode = code
     assert(typeof state === 'function', 'expected state')
     state = state(code)
@@ -243,7 +243,7 @@ export function createTokenizer(parser, initialize, from) {
   function consume(code) {
     assert(code === expectedCode, 'expected given code to equal expected code')
 
-    logDebug(`consume: ${code}`)
+    $logDebug(`consume: ${code}`)
 
     assert(
       consumed === undefined,
@@ -262,7 +262,7 @@ export function createTokenizer(parser, initialize, from) {
       point.column = 1
       point.offset += code === codes.carriageReturnLineFeed ? 2 : 1
       accountForPotentialSkip()
-      logDebug(`position: after eol: ${point}`)
+      $logDebug(`position: after eol: ${point}`)
     } else if (code !== codes.virtualSpace) {
       point.column++
       point.offset++
@@ -303,7 +303,7 @@ export function createTokenizer(parser, initialize, from) {
 
     assert(typeof type === 'string', 'expected string type')
     assert(type.length > 0, 'expected non-empty string')
-    logDebug(`enter: ${type}`)
+    $logDebug(`enter: ${type}`)
 
     context.events.push(['enter', token, context])
 
@@ -331,7 +331,7 @@ export function createTokenizer(parser, initialize, from) {
       'expected non-empty token (`' + type + '`)'
     )
 
-    logDebug(`exit: ${token.type}`)
+    $logDebug(`exit: ${token.type}`)
     context.events.push(['exit', token, context])
 
     return token
@@ -577,7 +577,7 @@ export function createTokenizer(parser, initialize, from) {
       context.events.length = startEventsIndex
       stack = startStack
       accountForPotentialSkip()
-      logDebug(`position: restore: ${JSON.stringify(point)}`)
+      $logDebug(`position: restore: ${JSON.stringify(point)}`)
     }
   }
 
@@ -714,8 +714,6 @@ function serializeChunks(chunks, expandTabs) {
 }
 
 /** @param {string} v  */
-function logDebug(v) {
-  if (process.env.mode === 'development') {
-    console.log(`[micromark] ${v}`)
-  }
+function $logDebug(v) {
+  console.log(`[micromark] ${v}`)
 }

--- a/packages/micromark/dev/lib/create-tokenizer.js
+++ b/packages/micromark/dev/lib/create-tokenizer.js
@@ -42,6 +42,7 @@ import {markdownLineEnding} from 'micromark-util-character'
 import {push, splice} from 'micromark-util-chunked'
 import {resolveAll} from 'micromark-util-resolve-all'
 import {codes, values} from 'micromark-util-symbol'
+import {IS_DEBUG} from '../debug.js'
 
 /**
  * Create a tokenizer.
@@ -177,7 +178,7 @@ export function createTokenizer(parser, initialize, from) {
   function defineSkip(value) {
     columnStart[value.line] = value.column
     accountForPotentialSkip()
-    $logDebug('position: define skip:', point)
+    if (IS_DEBUG) console.debug('[micromark] position: define skip:', point)
   }
 
   //
@@ -233,7 +234,13 @@ export function createTokenizer(parser, initialize, from) {
   function go(code) {
     assert(consumed === true, 'expected character to be consumed')
     consumed = undefined
-    $logDebug('main: passing', code, 'to', state && state.name)
+    if (IS_DEBUG)
+      console.debug(
+        '[micromark] main: passing',
+        code,
+        'to',
+        state && state.name
+      )
     expectedCode = code
     assert(typeof state === 'function', 'expected state')
     state = state(code)
@@ -243,7 +250,7 @@ export function createTokenizer(parser, initialize, from) {
   function consume(code) {
     assert(code === expectedCode, 'expected given code to equal expected code')
 
-    $logDebug('consume:', code)
+    if (IS_DEBUG) console.debug('[micromark] consume:', code)
 
     assert(
       consumed === undefined,
@@ -262,7 +269,7 @@ export function createTokenizer(parser, initialize, from) {
       point.column = 1
       point.offset += code === codes.carriageReturnLineFeed ? 2 : 1
       accountForPotentialSkip()
-      $logDebug('position: after eol:', point)
+      if (IS_DEBUG) console.debug('[micromark] position: after eol:', point)
     } else if (code !== codes.virtualSpace) {
       point.column++
       point.offset++
@@ -303,7 +310,7 @@ export function createTokenizer(parser, initialize, from) {
 
     assert(typeof type === 'string', 'expected string type')
     assert(type.length > 0, 'expected non-empty string')
-    $logDebug('enter:', type)
+    if (IS_DEBUG) console.debug('[micromark] enter:', type)
 
     context.events.push(['enter', token, context])
 
@@ -331,7 +338,7 @@ export function createTokenizer(parser, initialize, from) {
       'expected non-empty token (`' + type + '`)'
     )
 
-    $logDebug('exit:', token.type)
+    if (IS_DEBUG) console.debug('[micromark] exit:', token.type)
     context.events.push(['exit', token, context])
 
     return token
@@ -577,7 +584,7 @@ export function createTokenizer(parser, initialize, from) {
       context.events.length = startEventsIndex
       stack = startStack
       accountForPotentialSkip()
-      $logDebug('position: restore:', point)
+      if (IS_DEBUG) console.debug('[micromark] position: restore:', point)
     }
   }
 
@@ -712,8 +719,3 @@ function serializeChunks(chunks, expandTabs) {
 
   return result.join('')
 }
-
-const $logDebug =
-  typeof process !== 'undefined' && process.env.DEBUG?.includes('micromark')
-    ? console.debug.bind(console, '[micromark]')
-    : () => {}

--- a/packages/micromark/package.json
+++ b/packages/micromark/package.json
@@ -62,8 +62,6 @@
     }
   },
   "dependencies": {
-    "@types/debug": "^4.0.0",
-    "debug": "^4.0.0",
     "decode-named-character-reference": "^1.0.0",
     "devlop": "^1.0.0",
     "micromark-core-commonmark": "^2.0.0",


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amicromark&type=issues and https://github.com/orgs/micromark/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Replace `debug` with a runtime `console.log()` + babel plugin, this is by possible using existing plugins with dead code elimination:

```ts
if (DEBUG) {
  console.log("will be removed by dead code elimination when combined with define plugin")
}
```

for simplicity, but let me know if you have other preferences. This allows usage of `development` export under browser environment (e.g. in dev server), without bundling it (thanks to ESM)

<!--do not edit: pr-->
